### PR TITLE
Add missing translation string

### DIFF
--- a/modules/core/Cockpit/i18n/en.php
+++ b/modules/core/Cockpit/i18n/en.php
@@ -79,6 +79,7 @@ return [
     'Delete collection' => '',
     'You don\'t have any collections created.' => '',
     'Save Collection' => '',
+    'It seems you don\'t have any entries created.' => '',
     'Add entry' => '',
     'Edit entry' => '',
     'Delete entry' => '',


### PR DESCRIPTION
I've found this string missing from the list. It's used at https://github.com/aheinze/cockpit/blob/master/modules/core/Collections/views/entries.php
