### PR TITLE
Make sure email input fields also get serialized.

### DIFF
--- a/modules/core/Forms/views/api/form.php
+++ b/modules/core/Forms/views/api/form.php
@@ -73,6 +73,7 @@
                 case 'INPUT':
                     switch (form.elements[i].type) {
                     case 'text':
+                    case 'email':
                     case 'hidden':
                     case 'password':
                     case 'button':


### PR DESCRIPTION
When submitting a form, email input types didn't get serialized. An extra case fixed this issue.
