### PR TITLE
Accept multiple emails for receipt of form submissions

### DIFF
--- a/modules/core/Forms/bootstrap.php
+++ b/modules/core/Forms/bootstrap.php
@@ -26,7 +26,17 @@ $app->bind("/api/forms/submit/:form", function($params) use($app){
 
     if ($formdata = $app->param("form", false)) {
 
-        if (isset($frm["email"]) && filter_var($frm["email"], FILTER_VALIDATE_EMAIL)) {
+        if(isset($frm["email"])) {
+
+            $temp = array_map('trim', explode(',', $frm['email']));
+            $good_addresses = array();
+            foreach($temp as $to){
+                // Validate each email address individually, push if valid
+                if(filter_var($to, FILTER_VALIDATE_EMAIL)){
+                    array_push($good_addresses, $to);
+                };
+            };
+            $frm['email'] = implode(',', $good_addresses);
 
             $body = array();
 

--- a/modules/core/Forms/views/form.php
+++ b/modules/core/Forms/views/form.php
@@ -23,7 +23,7 @@
 
                     <div class="uk-form-row">
                         <label class="uk-text-small">Email</label>
-                        <input class="uk-width-1-1 uk-form-large" type="email" placeholder="@lang('Email form data to this adress')" data-ng-model="form.email">
+                        <input class="uk-width-1-1 uk-form-large" type="text" placeholder="@lang('Email form data to this adress')" data-ng-model="form.email">
 
                         <div class="uk-alert">
                             @lang('Leave the field empty if you don\'t want to recieve any form data via email.')

--- a/vendor/Mailer.php
+++ b/vendor/Mailer.php
@@ -65,7 +65,10 @@ class Mailer {
       $mail->AltBody = strip_tags($message);
       $mail->CharSet = 'utf-8';
 
-      $mail->AddAddress($to);
+      $to_array = explode(",", $to);
+      foreach ($to_array as $to_single) {
+        $mail->addAddress($to_single);
+      }
 
       if($mail->Body != $mail->AltBody) {
           $mail->IsHTML(true); // Set email format to HTML


### PR DESCRIPTION
I added the ability to specify multiple email addresses for receiving a form submission. Using the same form field (type changed to "text" instead of email), the addresses are separated by commas.  Each address is validated and only validated addresses are included in the mail object.
