### PR TITLE
Fixed a bug in Galleries#get_gallery_by_slug

### DIFF
--- a/modules/core/Galleries/bootstrap.php
+++ b/modules/core/Galleries/bootstrap.php
@@ -20,7 +20,7 @@ $this->module('galleries')->extend([
 
         $gallery = $galleries[$name];
 
-        return $gallery ? $gallery['images'] : null;
+        return $gallery ? $gallery : null;
     },
 
     'galleries' => function($options = []) use($app) {
@@ -48,7 +48,7 @@ $this->module('galleries')->extend([
 
         $gallery = $galleries[$slug];
 
-        return $gallery ? $gallery['images'] : null;
+        return $gallery ? $gallery : null;
     },
 ]);
 


### PR DESCRIPTION
This pull request fixes a bug on `get_gallery_by_slug` method in Galleries module. Instead of caching previously fetched galleries using the `$slug` variable it was mistakenly trying to use `$name` variable (probably copied over from `gallery($name)` method.

Furthermore, I think both `get_gallery_by_slug` and `gallery` should return the entire "Model" over the images in the gallery because it allows for the gallery name to be fetched dynamically. A use-case for this would be having a page to display a single gallery - probably at `http://mysite.com/galleries/my-gallery-slug` - fetched by `slug`, and still be able to access de gallery name to display in-page. It just doesn't make that much sense to me to return only the images when fetching a gallery considering this use-case, which I think is a pretty common one. I can make a pull request on this if you'd like to.
