### PR TITLE
added ObjectResized event when saving content in WYSIWYG

### DIFF
--- a/assets/js/angular/fields/wysiwyg.js
+++ b/assets/js/angular/fields/wysiwyg.js
@@ -72,6 +72,11 @@
                                 updateView();
                             }
                         });
+			// Update model on tinymce's event ObjectResized
+			ed.on('ObjectResized', function (e) {
+                            ed.save();
+                            updateView();
+                        });
 
                         if (expression.setup) {
                             scope.$eval(expression.setup);


### PR DESCRIPTION
While editing a collection item, if the you resize an image inside the WYSIWYG without making any other changes and save, the image's new dimensions will not be changed.
