### PR TITLE
Tweak to .htacces file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Manage content like collections, regions, forms and galleries which you can reus
 * PHP >= 5.4
 * PDO + SQLite (or MongoDB)
 * GD extension
-* support for .htaccess file
 
 make also sure that <code>$_SERVER['DOCUMENT_ROOT']</code> exists and is set correctly.
 


### PR DESCRIPTION
This changes .htaccess directive from `FilesMatch` to `Files ~`.
Result is exactly same, but FilesMatch is not supported by IdeaWebServer, which is a apparently fork of Apache 1.2.x. where it was not available either.

IdeaWebServer is used by few hosting companys in Poland.

I've also added a note about the requirement for .htaccess in the README.md because without it admin would now work (didn't try).

By the way, what for are file extensions sdb|s3db|db?
