### PR TITLE
Allow adding attributes to form element and disabling ajax validation

### DIFF
--- a/modules/core/Forms/bootstrap.php
+++ b/modules/core/Forms/bootstrap.php
@@ -102,15 +102,16 @@ $this->module("forms")->extend([
         return $forms[$name];
     },
 
-    "form" => function($name, $options = []) use($app) {
+    "form" => function($name, $options = [], $attributes = []) use($app) {
 
         $options = array_merge(array(
-            "id"    => uniqid("form"),
-            "class" => "",
-            "csrf"  => $app->hash($name)
+            "id"             => uniqid("form"),
+            "class"          => "",
+            "csrf"           => $app->hash($name),
+            "ajaxValidation" => true,
         ), $options);
 
-        $app->renderView("forms:views/api/form.php", compact('name', 'options'));
+        $app->renderView("forms:views/api/form.php", compact('name', 'options', 'attributes'));
     },
 
     "collectionById" => function($formId) use($app) {

--- a/modules/core/Forms/views/api/form.php
+++ b/modules/core/Forms/views/api/form.php
@@ -1,3 +1,4 @@
+@if ($options["ajaxValidation"])
 <script>
 
     setTimeout(function(){
@@ -62,7 +63,8 @@
 
 </script>
 
-<form id="{{ $options["id"] }}" name="{{ $name }}" class="{{ $options["class"] }}" action="@route('/api/forms/submit/'.$name)" method="post" onsubmit="return false;">
+@endif
+<form id="{{ $options["id"] }}" name="{{ $name }}" class="{{ $options["class"] }}" action="@route('/api/forms/submit/'.$name)" method="post"@if ($options["ajaxValidation"]) onsubmit="return false;"@endif @foreach ($attributes as $attrName => $attrValue) {{ $attrName }}="{{ $attrValue }}"@endforeach>
 <input type="hidden" name="__csrf" value="{{ $options["csrf"] }}">
 @if(isset($options["mailsubject"])):
 <input type="hidden" name="__mailsubject" value="{{ $options["mailsubject"] }}">


### PR DESCRIPTION
Features:
- Option to disable default ajax form validation by passing `"ajaxValidation" => false` parameter.
- Option to pass any form element attribute (`role="form"`, `ng-controller="ContactCtrl as ctrl"`) by 3rd parameter. _I left the class attribute in 2nd group for backward compatiblity_.

``` php
<?php cockpit(
   "forms:form",
   "contact",
    ["ajaxValidation" => false],
    ["role" => "form", "ng-controller" => "ContactCtrl as ctrl"]
) ?>
```
