### PR TITLE
Use full URL in generated paths

### DIFF
--- a/vendor/Lime/App.php
+++ b/vendor/Lime/App.php
@@ -475,7 +475,7 @@ class App implements \ArrayAccess {
             $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);
             $root = str_replace(DIRECTORY_SEPARATOR, '/', $this['docs_root']);
 
-            $url = '/'.ltrim(str_replace($root, '', $file), '/');
+            $url = $this['base_url'] . '/' . ltrim(str_replace($root, '', $file), '/');
         }
 
         /*


### PR DESCRIPTION
When application is installed in a subdirectory, it's not prepended in generated URLs.
This is apparent especially when generating assets.

As an example, correct similar behaviour is in the [routeUrl](https://github.com/aheinze/cockpit/blob/0.13.0/vendor/Lime/App.php#L330) method.
