### PR TITLE
More strictly deny access to database files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,5 @@
 # Deny access to database files
-<Files ~ "\.(sqlite|sdb|s3db|db)$">
+<Files ~ "\.(sqlite|SQLITE|sdb|SDB|s3db|S3DB|db|DB)$">
   Deny from all
 </Files>
 


### PR DESCRIPTION
Now "deny from all" rule correctly works for "my_base.db" and "my_base.DB" files.
