### PR TITLE
Flush output buffering for GZIP response

### DIFF
--- a/vendor/Lime/App.php
+++ b/vendor/Lime/App.php
@@ -878,7 +878,11 @@ class App implements \ArrayAccess {
 
             $self->trigger("after");
 
-            echo $self->response->flush();
+            $self->response->flush();
+
+            if ($self->response->gzip) {
+                ob_flush();
+            }
 
             $self->trigger("shutdown");
         });


### PR DESCRIPTION
There's an undocumented feature in cockpit for compressing the output,
however it's missing the function to flush output buffering, so browser ends up with invalid response.

In my opinion this functionality could be dropped as it's easier to setup compression in `.htaccess` file which is required anyway by default.
