### PR TITLE
Filesystem::ls throws LogicException for subfolderes

### DIFF
--- a/vendor/Lime/Helper/Filesystem.php
+++ b/vendor/Lime/Helper/Filesystem.php
@@ -32,8 +32,9 @@ class Filesystem extends \Lime\Helper {
 
         foreach (new \DirectoryIterator($dir) as $file) {
 
-            if($file->isDot()) continue;
-            if($pattern && !fnmatch($pattern, $file->getBasename())) continue;
+            if (!$file->isFile()) continue;
+
+            if ($pattern && !fnmatch($pattern, $file->getBasename())) continue;
 
             $lst[] = new \SplFileObject($file->getRealPath());
         }


### PR DESCRIPTION
[new SplFileObject](https://github.com/aheinze/cockpit/blob/master/vendor/Lime/Helper/Filesystem.php#L38) will throw LogicException when received a directory:

```
Cannot use SplFileObject with directories
```
