### PR TITLE
Media previews thumbs contain, to see them whole.

### DIFF
--- a/assets/js/angular/directives/mediapreview.js
+++ b/assets/js/angular/directives/mediapreview.js
@@ -24,7 +24,7 @@
 
                                 var style = elm.attr('style') || '';
 
-                                $r = '<div class="media-url-preview" style="background-image:url('+encodeURI(url)+');background-size:cover;'+style+'"></div>';
+                                $r = '<div class="media-url-preview" style="background-image:url('+encodeURI(url)+');background-size:contain;'+style+'"></div>';
                             }
 
                             if (url.match(/\.(mp4|mpeg|ogv|webm|wmv)$/i)) {


### PR DESCRIPTION
Square previews looking great, but we need to see images proportion/orientation to better organize. `Next` has it already. So 13.1 should have it too.
