### PR TITLE
Customize default gallery fields using registry `galleryDefaultFields` key

### DIFF
--- a/modules/core/Cockpit/Controller/Settings.php
+++ b/modules/core/Cockpit/Controller/Settings.php
@@ -116,6 +116,24 @@ class Settings extends \Cockpit\Controller {
         return false;
     }
 
+    public function getRegistry() {
+
+        $key = $this->param("key", false);
+
+        if ($key !== false) {
+
+            $registry = $this->app->memory->get("cockpit.api.registry");
+
+            if (isset($registry[$key])) {
+                return $registry[$key];
+            }
+        } else {
+            return $this->app->memory->get("cockpit.api.registry");
+        }
+
+        return false;
+    }
+
     public function saveRegistry() {
 
         $registry = $this->param("registry", false);

--- a/modules/core/Galleries/assets/js/gallery.js
+++ b/modules/core/Galleries/assets/js/gallery.js
@@ -2,10 +2,11 @@
 
     App.module.controller("gallery", function($scope, $rootScope, $http, $timeout, Contentfields){
 
-        var id         = $("[data-ng-controller='gallery']").data("id"),
-            site_base  = COCKPIT_SITE_BASE_URL.replace(/^\/+|\/+$/g, ""),
-            media_base = COCKPIT_MEDIA_BASE_URL.replace(/^\/+|\/+$/g, ""),
-            site2media = media_base.replace(site_base, "").replace(/^\/+|\/+$/g, "");
+        var id            = $("[data-ng-controller='gallery']").data("id"),
+            site_base     = COCKPIT_SITE_BASE_URL.replace(/^\/+|\/+$/g, ""),
+            media_base    = COCKPIT_MEDIA_BASE_URL.replace(/^\/+|\/+$/g, ""),
+            site2media    = media_base.replace(site_base, "").replace(/^\/+|\/+$/g, ""),
+            defaultFields = [{"name":"caption","type":"html"}, {"name":"url","type":"text"}];
 
         $scope.groups        = [];
         $scope.metaimage     = {};
@@ -24,9 +25,17 @@
 
         } else {
 
+            $http.post(App.route("/settings/getRegistry"), {key: "galleryDefaultFields"}, {responseType:"json"}).success(function(data){
+
+                if (data && Object.keys(data).length) {
+                    $scope.gallery.fields = data;
+                }
+
+            });
+
             $scope.gallery = {
                 name: "",
-                fields:[{"name":"caption","type":"html"}, {"name":"url","type":"text"}],
+                fields: defaultFields,
                 images: [],
                 group: ""
             };


### PR DESCRIPTION
**Issue:** Creating new galleries requires setting same fields over and over again.

**Feature:** To stop repeating ourselves and overriding fields manually, set custom defaults for gallery image fields using simple registry key `galleryDefaultFields` and add own fields as JSON string as its value.

![screen shot 2016-01-02 at 18 55 43](https://cloud.githubusercontent.com/assets/387611/12075483/7bccaf38-b182-11e5-93c8-4ba3c63d02d4.png)

Would require to update docs for others to use this feature.
