### PR TITLE
pass along JS options to UIKit html editor and CodeMirror for markdown fields

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -1762,6 +1762,15 @@ riot.tag2('field-html', '<textarea ref="input" class="uk-visibility-hidden"></te
 
                 $this.refs.input.value = $this.value;
 
+                //get codemirror options from JSON options and merge in opts
+                if(opts.htmleditoroptions){
+                    var co=opts.htmleditoroptions;
+                    for(var prop in co){
+                        if(!(prop in opts) || opts[prop] === undefined)
+                        opts[prop]=co[prop];
+                    }
+                }
+
                 editor = UIkit.htmleditor(this.refs.input, opts);
                 editor.editor.on('change', function() {
                     $this.$setValue(editor.editor.getValue());
@@ -1923,7 +1932,7 @@ riot.tag2('field-location', '<div class="uk-alert" if="{!apiready}"> Loading map
 
 });
 
-riot.tag2('field-markdown', '<field-html ref="input" markdown="true" bind="{opts.bind}" height="{opts.height}"></field-html>', '', '', function(opts) {
+riot.tag2('field-markdown', '<field-html ref="input" markdown="true" bind="{opts.bind}" htmleditoroptions="{opts.htmleditor}" height="{opts.height}"></field-html>', '', '', function(opts) {
 });
 
 riot.tag2('field-multipleselect', '<div class="{options.length > 10 ? \'uk-scrollable-box\':\'\'}"> <div class="uk-margin-small-top" each="{option in options}"> <a data-value="{option}" class="{parent.selected.indexOf(option)!==-1 ? \'uk-text-primary\':\'uk-text-muted\'}" onclick="{parent.toggle}" title="{option}"> <i class="uk-icon-{parent.selected.indexOf(option)!==-1 ? \'circle\':\'circle-o\'} uk-margin-small-right"></i> {option} </a> </div> </div> <span class="uk-text-small uk-text-muted" if="{options.length > 10}">{selected.length} {App.i18n.get(\'selected\')}</span>', '', '', function(opts) {

--- a/modules/Cockpit/assets/components/field-html.tag
+++ b/modules/Cockpit/assets/components/field-html.tag
@@ -38,6 +38,15 @@
 
                 $this.refs.input.value = $this.value;
 
+                //pass along codemirror options to htmleditor/codemirror
+                if(opts.htmleditoroptions
+                    var co=opts.htmleditoroptions;
+                    for(var prop in co){
+                        if(!(prop in opts) || opts[prop] === undefined)
+                            opts[prop]=co[prop];
+                    }
+                }
+
                 editor = UIkit.htmleditor(this.refs.input, opts);
                 editor.editor.on('change', function() {
                     $this.$setValue(editor.editor.getValue());

--- a/modules/Cockpit/assets/components/field-markdown.tag
+++ b/modules/Cockpit/assets/components/field-markdown.tag
@@ -1,6 +1,6 @@
 <field-markdown>
 
-    <field-html ref="input" markdown="true" bind="{ opts.bind }" height="{opts.height}"></field-html>
+    <field-html ref="input" markdown="true" bind="{ opts.bind }" htmleditoroptions="{ opts.htmleditor}" height="{opts.height}"></field-html>
 
     <script>
         


### PR DESCRIPTION
Added ability to pass configuration options, other than `height`, to the htmleditor used also for markdown. 

Useful for example, to have side by side editing of markdown:  For example, in the options of a collection's field, try writing this: 

    {
        "height": 200, 
        "htmleditor": {
            "mode": "split",
            "maxsplitsize": 800,
            "codemirror": {
                "lineNumbers": true
            }
        }
    }

The `lineNumbers` options in useless in markdown, but just an example here.
It's a bit less useful now than one year ago, since now you can specify the `height` property of the editor as a plain option, but nonetheless can be handy to pass specific options to the underlying UIKit html editor or directly to codemirror.
This is the list of UiKit options (as derived from UIKit' `htmleditor.js` files, is (with defaults)

    {
        iframe       : false,
        mode         : 'split',
        markdown     : false,
        autocomplete : true,
        enablescripts: false,
        height       : 500,
        maxsplitsize : 1000, 
        toolbar      : [ 'bold', 'italic', 'strike', 'link', 'image', 'blockquote', 'listUl', 'listOl' ],
        lblPreview   : 'Preview',
        lblCodeview  : 'HTML',
        lblMarkedview: 'Markdown'
   }

while if you add a `codemirror` key under `htmleditor` key, you can pass options direclty to codemirror as per  [CodeMirror config options](https://codemirror.net/doc/manual.html#api_configuration)