### PR TITLE
Improves Defining CLI Constant In bootstrap.php

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,7 +5,9 @@
  */
 define('COCKPIT_START_TIME', microtime(true));
 
-if (!defined('COCKPIT_CLI')) define('COCKPIT_CLI', PHP_SAPI == 'cli');
+if (!defined('COCKPIT_CLI')) {
+    define('COCKPIT_CLI', PHP_SAPI === 'cli');
+}
 
 /*
  * Autoload from lib folder (PSR-0)


### PR DESCRIPTION
* Uses identical operator
* Adds a block to if statement (recommended by PSR-2)

Hints comes from Php Inspections (EA Extended) too.