### PR TITLE
[Next] Tags-Field - apply tag field with comma, fix #786

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea
 .env
 composer.lock
+package-lock.json
 /lib/**/docs/*
 /lib/**/tests/*
 /lib/**/example/*

--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -3244,7 +3244,7 @@ riot.tag2('field-tags', '<div class="uk-grid uk-grid-small uk-flex-middle" data-
 
                     var value = e.type=='keydown' ? $this.refs.input.value : data.value;
 
-                    if (e.type=='keydown' && e.keyCode != 13) {
+                    if (e.type=='keydown' && e.keyCode != 13 && e.keyCode != 188) {
                         return;
                     }
 

--- a/modules/Cockpit/assets/components/field-tags.tag
+++ b/modules/Cockpit/assets/components/field-tags.tag
@@ -47,7 +47,7 @@
 
                     var value = e.type=='keydown' ? $this.refs.input.value : data.value;
 
-                    if (e.type=='keydown' && e.keyCode != 13) {
+                    if (e.type=='keydown' && e.keyCode != 13 && e.keyCode != 188) {
                         return;
                     }
 


### PR DESCRIPTION
Now it's possible to press enter or comma to separate tags.