### PR TITLE
Fix method name in SimpleImage

### DIFF
--- a/lib/Lime/Helper/Image.php
+++ b/lib/Lime/Helper/Image.php
@@ -39,7 +39,7 @@ class Img {
     }
 
     public function show($format=null, $quality=100) {
-        $this->image->output($format, $quality);
+        $this->image->toScreen($format, $quality);
     }
 
     public function blur($passes = 1, $type = 'gaussian') {


### PR DESCRIPTION
Fix method call from `$this->image->output` to `$this->image->toScreen` as   [claviska\SimpleImage](https://github.com/claviska/SimpleImage/tree/3.3.3) doesn't have such method