### PR TITLE
Remove extra slash when creating a thumbnail

### DIFF
--- a/lib/FileStorage.php
+++ b/lib/FileStorage.php
@@ -48,7 +48,7 @@ class FileStorage {
             if (!$path) {
                 $url = $this->config[$prefix]['url'];
             } elseif ($this->has($file)) {
-                $url = rtrim($this->config[$prefix]['url'], '/').'/'.$path;
+                $url = rtrim($this->config[$prefix]['url'], '/').'/'.ltrim($path, '/');
             }
         }
 


### PR DESCRIPTION
When creating a thumbnail using cockpit module, path which is passed to `FileStorage::getUrl` has tripple slashes (`thumbs:///foobar.jpg`) as set [here](https://github.com/agentejo/cockpit/blob/0.6.0/modules/Cockpit/bootstrap.php#L190).

This is fine, howewever after `getUrl` method replaces placeholder it adds one more slash [here](https://github.com/agentejo/cockpit/blob/0.6.0/lib/FileStorage.php#L51).

This commit uses ltrim to make sure that there are no extra slashes in resolved URL.