### PR TITLE
Add option to use multiple filters when generating image thumbnail

### DIFF
--- a/modules/Cockpit/Controller/RestApi.php
+++ b/modules/Cockpit/Controller/RestApi.php
@@ -141,6 +141,7 @@ class RestApi extends \LimeExtra\Controller {
             'src' => $this->param('src', false),
             'mode' => $this->param('m', 'thumbnail'),
             'fp' => $this->param('fp', null),
+            'filters' => (array) $this->param('f', []),
             'width' => intval($this->param('w', null)),
             'height' => intval($this->param('h', null)),
             'quality' => intval($this->param('q', 100)),
@@ -149,6 +150,7 @@ class RestApi extends \LimeExtra\Controller {
             'output' => intval($this->param('o', false))
         ];
 
+        // Set single filter when available
         foreach ([
             'blur', 'brighten',
             'colorize', 'contrast',

--- a/modules/Cockpit/Controller/Utils.php
+++ b/modules/Cockpit/Controller/Utils.php
@@ -8,7 +8,9 @@ class Utils extends \Cockpit\AuthController {
 
         $options = [
             'src' => $this->param('src', false),
+            'fp' => $this->param('fp', null),
             'mode' => $this->param('m', 'thumbnail'),
+            'filters' => (array) $this->param('f', []),
             'width' => intval($this->param('w', null)),
             'height' => intval($this->param('h', null)),
             'quality' => intval($this->param('q', 85)),
@@ -17,11 +19,12 @@ class Utils extends \Cockpit\AuthController {
             'output' => intval($this->param('o', false)),
         ];
 
+        // Set single filter when available
         foreach([
-            'blur', 'brighten', 
-            'colorize', 'contrast', 
-            'darken', 'desaturate', 
-            'edge detect', 'emboss', 
+            'blur', 'brighten',
+            'colorize', 'contrast',
+            'darken', 'desaturate',
+            'edge detect', 'emboss',
             'flip', 'invert', 'opacity', 'pixelate', 'sepia', 'sharpen', 'sketch'
         ] as $f) {
             if ($this->param($f)) $options[$f] = $this->param($f);

--- a/modules/Cockpit/bootstrap.php
+++ b/modules/Cockpit/bootstrap.php
@@ -75,6 +75,23 @@ $this->module('cockpit')->extend([
         return $this->app->helper('fs')->write($container, "<?php\n return {$export};");
     },
 
+    /**
+     * Generate thumbnail
+     * @param array $options {
+     *   @var string [cachefolder=thumbs://] - Cache folder
+     *   @var string $source - Source file path
+     *   @var string [$mode=thumbnail] - One of thumbnail|bestFit|resize|fitToWidth|fitToHeight
+     *   @var string [$fp] - Position
+     *   @var array [$filters] - Associative array of filters and it's options: ['sepia', 'sharpen']
+     *   @var integer [$width] - Output width
+     *   @var integer [$height] - Output height
+     *   @var integer [$quality=100] - Output quality
+     *   @var boolean [$rebuild=false] - Force image rebuild
+     *   @var boolean [$base64=false] - Base64 output
+     *   @var boolean [$output=false] - Echo response and exit application
+     * }
+     * @return string URL to file or Base64 output
+     */
     'thumbnail' => function($options) {
 
         $options = array_merge(array(
@@ -82,7 +99,7 @@ $this->module('cockpit')->extend([
             'src' => '',
             'mode' => 'thumbnail',
             'fp' => null,
-            'filter' => '',
+            'filters' => [],
             'width' => false,
             'height' => false,
             'quality' => 100,
@@ -215,10 +232,24 @@ $this->module('cockpit')->extend([
                     'flip', 'invert', 'opacity', 'pixelate', 'sepia', 'sharpen', 'sketch'
                 ];
 
+                // Apply single filter
                 foreach ($_filters as $f) {
 
                     if (isset($options[$f])) {
                         $img->{$f}($options[$f]);
+                    }
+                }
+
+                // Apply multiple filters
+                foreach ($filters as $filterName => $filterOptions) {
+                    // Handle non-associative array
+                    if (is_int($filterName)) {
+                        $filterName = $filterOptions;
+                        $filterOptions = [];
+                    }
+
+                    if (in_array($filterName, $_filters)) {
+                        call_user_func_array([$img, $filterName], (array) $filterOptions);
                     }
                 }
 


### PR DESCRIPTION
Simple usage:

- Using REST API
```
api/cockpit/image?token=xxtokenxx&src=foobar.jpg&w=300
    &f[]=desaturate
    &f[]=sharpen
```
- PHP
```php
$fileUrl = cockpit()->module('cockpit')->thumbnail([
    'src' => 'foobar.jpg',
    'filters' => ['desaturate', 'sharpen'],
]);
```

Advanced usage with parameters:

- Rest API
```
api/cockpit/image?token=xxtokenxx&src=foobar.jpg&w=300
    &f[]=desaturate
    &f[brighten]=25
    &f[blur][]=selective
    &f[blur][]=2
```
- PHP
```php
$fileUrl = cockpit()->module('cockpit')->thumbnail([
    'src' => 'foobar.jpg',
    'filters' => [
        'desaturate',
        'brighten' => 25,
        'blur' => ['selective', '2'],
    ],
]);
```