### PR TITLE
Adding generic acl checks for controllers (RFC)

### DIFF
--- a/modules/Cockpit/AuthController.php
+++ b/modules/Cockpit/AuthController.php
@@ -7,6 +7,13 @@ class AuthController extends \LimeExtra\Controller {
     protected $layout = 'cockpit:views/layouts/app.php';
     protected $user;
 
+
+    /** Controller access group */
+    protected $accessGroup;
+
+    /** Controller access resource */
+    protected $accessResource;
+
     public function __construct($app) {
 
         $user = $app->module('cockpit')->getUser();
@@ -23,8 +30,24 @@ class AuthController extends \LimeExtra\Controller {
 
         $controller = strtolower(str_replace('\\', '.', get_class($this)));
 
+        // Resolve access group and resource (ie. cockpit, settings)
+        list ($this->accessGroup, ,$this->accessResource) = explode('\\', strtolower(get_class($this)));
+
         $app->trigger("app.{$controller}.init", [$this]);
 
+    }
+
+    /**
+     * Check if current user has access to current resource
+     * @param array [$actions]
+     * @return boolean
+     */
+    protected function hasAccess($actions = []) {
+        return $this->module('cockpit')->isSuperAdmin() || $this->module('cockpit')->hasAccess(
+            $this->accessGroup,
+            $this->accessResource,
+            $actions
+        );
     }
 
 }

--- a/modules/Cockpit/Controller/Settings.php
+++ b/modules/Cockpit/Controller/Settings.php
@@ -6,10 +6,17 @@ class Settings extends \Cockpit\AuthController {
 
 
     public function index() {
+        if (!$this->hasAccess()) {
+            return $this->helper('admin')->denyRequest();
+        }
+
         return $this->render('cockpit:views/settings/index.php');
     }
 
     public function info() {
+        if (!$this->hasAccess()) {
+            return $this->helper('admin')->denyRequest();
+        }
 
         $info                  = [];
 


### PR DESCRIPTION
I've noticed that even when user is not given access to cockpit settings, he/she is still able to see the page (for instance by navigating manually to `http://site.tld/cockpit/settings` url).

Some methods check for permission access, other that are responsible to show pages may not.

In this PR I've extended [AuthController](https://github.com/agentejo/cockpit/blob/0.6.1/modules/Cockpit/AuthController.php) by adding `hasAccess` method. During initialization group and resource is auto resolved from controller class name, but it's possible to set it in extending class.

Usage example in the settings controller:
```php
class Settings extends \Cockpit\AuthController {
    public function index() {
        // Access check
        if (!$this->hasAccess()) {
            return $this->helper('admin')->denyRequest();
        }

        return $this->render('cockpit:views/settings/index.php');
}
```

However it's possible to declare group and resource in extending class:
```php
class Settings extends \Cockpit\AuthController {
    protected $accessGroup = 'cockpit';
    protected $accessResource = 'settings';
```