### PR TITLE
Ability to use geolocation coords

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -2821,6 +2821,23 @@ riot.tag2('field-location', '<div class="uk-alert" if="{!apiready}"> Loading map
                         map.panTo(marker.getLatLng());
                         pla.close();
                         pla.setVal('');
+                    }).on('suggestions', function (e) {
+                      var coords = e.query.match(/^(\-?\d+(?:\.\d+)?),\s*(\-?\d+(?:\.\d+)?)$/);
+
+                      if (!coords) {
+                        return;
+                      }
+
+                      var latlng = {
+                        lat: parseFloat(coords[1]),
+                        lng: parseFloat(coords[2])
+                      };
+
+                      $this.$setValue(latlng);
+                      marker.setLatLng(latlng).update();
+                      map.panTo(marker.getLatLng());
+                      pla.close();
+                      pla.setVal('');
                     });
 
                 }, 50);

--- a/modules/Cockpit/assets/components/field-location.tag
+++ b/modules/Cockpit/assets/components/field-location.tag
@@ -80,6 +80,23 @@
                         map.panTo(marker.getLatLng());
                         pla.close();
                         pla.setVal('');
+                    }).on('suggestions', function (e) {
+                      var coords = e.query.match(/^(\-?\d+(?:\.\d+)?),\s*(\-?\d+(?:\.\d+)?)$/);
+
+                      if (!coords) {
+                        return;
+                      }
+
+                      var latlng = {
+                        lat: parseFloat(coords[1]),
+                        lng: parseFloat(coords[2])
+                      };
+
+                      $this.$setValue(latlng);
+                      marker.setLatLng(latlng).update();
+                      map.panTo(marker.getLatLng());
+                      pla.close();
+                      pla.setVal('');
                     });
 
                 }, 50);


### PR DESCRIPTION
Adding ability to use geolocation coords (like `53.55909862554551, 9.998652343749995`) in the places autocomplete input element.

This is handy, when one would like to add location which
- address has changed recently (new street name) and isn't available in autocomplete databse yet
- doesn't have address (place outside of city like in mountains, sea, etc)