### PR TITLE
avoid redirect to cockpit.start if unauthorized

### DIFF
--- a/modules/Cockpit/admin.php
+++ b/modules/Cockpit/admin.php
@@ -82,7 +82,7 @@ $app['app.assets.base'] = $assets;
 
 $app->bind('/', function(){
 
-    if ($this['cockpit.start'] && $this->module('cockpit')->getUser()) {
+    if ($this['cockpit.start'] && $this->module('cockpit')->getUser() && $this->module('cockpit')->hasaccess('cockpit', 'cockpit.start')) {
         $this->reroute($this['cockpit.start']);
     }
 


### PR DESCRIPTION
If I use `cockpit.start` in config.yaml to skip the dashboard after login and I am not authorized  to see this page (non-admin user), I see a 401 after the login. The button "Get back" leads to `/cockpit`, which redirects me again to the 401.

I added a check, if the user has access before redirecting.