### PR TITLE
added export of entries to RestApi of Forms

### DIFF
--- a/modules/Forms/Controller/RestApi.php
+++ b/modules/Forms/Controller/RestApi.php
@@ -18,4 +18,17 @@ class RestApi extends \LimeExtra\Controller {
 
         return false;
     }
+	
+	public function export($form) {
+
+        $form = $this->module('forms')->form($form);
+
+        if (!$form) {
+            return false;
+        }
+
+        $entries = $this->module('forms')->find($form['name']);
+
+        return json_encode($entries, JSON_PRETTY_PRINT);
+    }
 }


### PR DESCRIPTION
- would close #848 
- the export method is mostly a copy of the method found in Admin.php, so it gives the same output (JSON) as a click on "Export" in the backend

I'm not sure about the naming conventions. Because I mostly copied the method, I also copied the name. Maybe "entries" is an alternative to "export"