### PR TITLE
set .tag files as javascript to avoid xml parsing errors in firefox console

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -39,7 +39,7 @@ Options -Indexes
 
 AddDefaultCharset utf-8
 
-AddType application/javascript          js jsonp
+AddType application/javascript          js jsonp tag
 AddType application/json                json
 
 # Audio


### PR DESCRIPTION
.tag files were interpreted as xml files (in Firefox), where symbols like "{}" are not allowed. Setting the mime type in .htaccess to application/javascript fixes this behavior.