### PR TITLE
fix grammar in upload failure notification

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -159,7 +159,7 @@ riot.tag2('cp-assets', '<div ref="list" show="{mode==\'list\'}"> <div ref="uploa
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {
@@ -677,7 +677,7 @@ riot.tag2('cp-finder', '<div show="{App.Utils.count(data)}"> <div class="uk-clea
                             $this.refs.uploadprogress.classList.add('uk-hidden');
 
                             if (response && response.failed && response.failed.length) {
-                                App.ui.notify("File(s) failed to uploaded.", "danger");
+                                App.ui.notify("File(s) failed to upload.", "danger");
                             }
 
                             if (!response) {
@@ -1592,7 +1592,7 @@ riot.tag2('field-asset', '<div ref="uploadprogress" class="uk-margin uk-hidden">
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {
@@ -1871,7 +1871,7 @@ riot.tag2('field-file', '<div class="uk-panel uk-panel-box uk-panel-card "> <div
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {
@@ -1985,7 +1985,7 @@ riot.tag2('field-gallery', '<div ref="uploadprogress" class="uk-margin uk-hidden
                     complete: function(response) {
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {
@@ -2265,7 +2265,7 @@ riot.tag2('field-image', '<div ref="uploadprogress" class="uk-margin uk-hidden">
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {

--- a/modules/Cockpit/assets/components/cp-assets.tag
+++ b/modules/Cockpit/assets/components/cp-assets.tag
@@ -345,7 +345,7 @@
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {

--- a/modules/Cockpit/assets/components/cp-finder.tag
+++ b/modules/Cockpit/assets/components/cp-finder.tag
@@ -358,7 +358,7 @@
                             $this.refs.uploadprogress.classList.add('uk-hidden');
 
                             if (response && response.failed && response.failed.length) {
-                                App.ui.notify("File(s) failed to uploaded.", "danger");
+                                App.ui.notify("File(s) failed to upload.", "danger");
                             }
 
                             if (!response) {

--- a/modules/Cockpit/assets/components/field-asset.tag
+++ b/modules/Cockpit/assets/components/field-asset.tag
@@ -94,7 +94,7 @@
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {

--- a/modules/Cockpit/assets/components/field-file.tag
+++ b/modules/Cockpit/assets/components/field-file.tag
@@ -69,7 +69,7 @@
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {

--- a/modules/Cockpit/assets/components/field-gallery.tag
+++ b/modules/Cockpit/assets/components/field-gallery.tag
@@ -174,7 +174,7 @@
                     complete: function(response) {
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {

--- a/modules/Cockpit/assets/components/field-image.tag
+++ b/modules/Cockpit/assets/components/field-image.tag
@@ -120,7 +120,7 @@
                         $this.refs.uploadprogress.classList.add('uk-hidden');
 
                         if (response && response.failed && response.failed.length) {
-                            App.ui.notify("File(s) failed to uploaded.", "danger");
+                            App.ui.notify("File(s) failed to upload.", "danger");
                         }
 
                         if (response && Array.isArray(response.assets) && response.assets.length) {


### PR DESCRIPTION
Very minor, but "File(s) failed to uploaded" is not grammatically correct. This PR corrects all occurrences of this message to "File(s) failed to upload".