### PR TITLE
Cross browser rendering for active menu item fixed

### DIFF
--- a/assets/app/css/style.less
+++ b/assets/app/css/style.less
@@ -112,6 +112,7 @@
     width: 100%;
     border-bottom: 3px @global-primary-background solid;
     bottom: -20px;
+    left: 0;
 }
 
 .app-main {


### PR DESCRIPTION
Some browsers (at least Firefox, just to name one) fail to position the pseudo after element right below the active menu item without a horizontal position anker.