### PR TITLE
added value-label functionality to field-select and field-multipleselect

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -2894,7 +2894,7 @@ riot.tag2('field-location', '<div class="uk-alert" if="{!apiready}"> Loading map
 riot.tag2('field-markdown', '<field-html ref="input" markdown="true" bind="{opts.bind}" height="{opts.height}"></field-html>', '', '', function(opts) {
 });
 
-riot.tag2('field-multipleselect', '<div class="{options.length > 10 ? \'uk-scrollable-box\':\'\'}"> <div class="uk-margin-small-top" each="{option in options}"> <a data-value="{option}" class="{parent.selected.indexOf(option)!==-1 ? \'uk-text-primary\':\'uk-text-muted\'}" onclick="{parent.toggle}" title="{option}"> <i class="uk-icon-{parent.selected.indexOf(option)!==-1 ? \'circle\':\'circle-o\'} uk-margin-small-right"></i> {option} </a> </div> </div> <span class="uk-text-small uk-text-muted" if="{options.length > 10}">{selected.length} {App.i18n.get(\'selected\')}</span>', '', '', function(opts) {
+riot.tag2('field-multipleselect', '<div class="{options.length > 10 ? \'uk-scrollable-box\':\'\'}"> <div class="uk-margin-small-top" each="{option in options}"> <a data-value="{option.value}" class="{parent.selected.indexOf(option.value)!==-1 ? \'uk-text-primary\':\'uk-text-muted\'}" onclick="{parent.toggle}" title="{option.label}"> <i class="uk-icon-{parent.selected.indexOf(option.value)!==-1 ? \'circle\':\'circle-o\'} uk-margin-small-right"></i> {option.label} </a> </div> </div> <span class="uk-text-small uk-text-muted" if="{options.length > 10}">{selected.length} {App.i18n.get(\'selected\')}</span>', '', '', function(opts) {
 
         var $this = this;
 
@@ -2907,18 +2907,15 @@ riot.tag2('field-multipleselect', '<div class="{options.length > 10 ? \'uk-scrol
 
         this.on('update', function() {
 
-            this.options = opts.options || [];
-
-            if (typeof(this.options) === 'string') {
-
-                var options = [];
-
-                this.options.split(',').forEach(function(option) {
-                    options.push(option.trim());
+            this.options = (typeof(opts.options) === 'string' ? opts.options.split(',') : opts.options || [])
+                .map(function(option) {
+                    option = {
+                      value : (option.hasOwnProperty('value') ? option.value.toString().trim() : option.toString().trim()),
+                      label : (option.hasOwnProperty('label') ? option.label.toString().trim() : option.toString().trim())
+                    };
+                    return option;
                 });
 
-                this.options = options;
-            }
         });
 
         this.$initBind = function() {
@@ -2940,7 +2937,7 @@ riot.tag2('field-multipleselect', '<div class="{options.length > 10 ? \'uk-scrol
 
         this.toggle = function(e) {
 
-            var option = e.item.option,
+            var option = e.item.option.value,
                 index  = this.selected.indexOf(option);
 
             if (index == -1) {
@@ -3218,9 +3215,10 @@ riot.tag2('field-repeater', '<div class="uk-alert" show="{!items.length}"> {App.
 
 });
 
-riot.tag2('field-select', '<select ref="input" class="uk-width-1-1 {opts.cls}" bind="{opts.bind}"> <option value=""></option> <option each="{option,idx in options}" riot-value="{option}" selected="{parent.root.$value === option}">{option}</option> </select>', '', '', function(opts) {
+riot.tag2('field-select', '<select ref="input" class="uk-width-1-1 {opts.cls}" bind="{opts.bind}"> <option value=""></option> <option each="{option,idx in options}" riot-value="{option.value}" selected="{parent.root.$value === option.value}">{option.label}</option> </select>', '', '', function(opts) {
 
         this.on('mount', function() {
+            this.refs.input.value = this.root.$value;
             this.update();
         });
 
@@ -3231,10 +3229,13 @@ riot.tag2('field-select', '<select ref="input" class="uk-width-1-1 {opts.cls}" b
 
             this.options = (typeof(opts.options) === 'string' ? opts.options.split(',') : opts.options || [])
                 .map(function(option) {
-                    return option.toString().trim();
+                    option = {
+                      value : (option.hasOwnProperty('value') ? option.value.toString().trim() : option.toString().trim()),
+                      label : (option.hasOwnProperty('label') ? option.label.toString().trim() : option.toString().trim())
+                    };
+                    return option;
                 });
 
-            this.refs.input.value = this.root.$value;
         });
 
 });

--- a/modules/Cockpit/assets/components/field-multipleselect.tag
+++ b/modules/Cockpit/assets/components/field-multipleselect.tag
@@ -1,9 +1,9 @@
 <field-multipleselect>
     <div class="{ options.length > 10 ? 'uk-scrollable-box':'' }">
         <div class="uk-margin-small-top" each="{option in options}">
-            <a data-value="{ option }" class="{ parent.selected.indexOf(option)!==-1 ? 'uk-text-primary':'uk-text-muted' }" onclick="{ parent.toggle }" title="{ option }">
-                <i class="uk-icon-{ parent.selected.indexOf(option)!==-1 ? 'circle':'circle-o' } uk-margin-small-right"></i>
-                { option }
+            <a data-value="{ option.value }" class="{ parent.selected.indexOf(option.value)!==-1 ? 'uk-text-primary':'uk-text-muted' }" onclick="{ parent.toggle }" title="{ option.label }">
+                <i class="uk-icon-{ parent.selected.indexOf(option.value)!==-1 ? 'circle':'circle-o' } uk-margin-small-right"></i>
+                { option.label }
             </a>
         </div>
     </div>
@@ -21,19 +21,16 @@
         });
 
         this.on('update', function() {
-
-            this.options = opts.options || [];
-
-            if (typeof(this.options) === 'string') {
-
-                var options = [];
-
-                this.options.split(',').forEach(function(option) {
-                    options.push(option.trim());
+            
+            this.options = (typeof(opts.options) === 'string' ? opts.options.split(',') : opts.options || [])
+                .map(function(option) {
+                    option = {
+                      value : (option.hasOwnProperty('value') ? option.value.toString().trim() : option.toString().trim()),
+                      label : (option.hasOwnProperty('label') ? option.label.toString().trim() : option.toString().trim())
+                    };
+                    return option;
                 });
 
-                this.options = options;
-            }
         });
 
         this.$initBind = function() {
@@ -55,7 +52,7 @@
 
         toggle(e) {
 
-            var option = e.item.option,
+            var option = e.item.option.value,
                 index  = this.selected.indexOf(option);
 
             if (index == -1) {

--- a/modules/Cockpit/assets/components/field-select.tag
+++ b/modules/Cockpit/assets/components/field-select.tag
@@ -2,12 +2,13 @@
 
     <select ref="input" class="uk-width-1-1 {opts.cls}" bind="{ opts.bind }">
         <option value=""></option>
-        <option each="{ option,idx in options }" value="{ option }" selected="{ parent.root.$value === option }">{ option }</option>
+        <option each="{ option,idx in options }" value="{ option.value }" selected="{ parent.root.$value === option.value }">{ option.label }</option>
     </select>
 
     <script>
 
         this.on('mount', function() {
+            this.refs.input.value = this.root.$value;
             this.update();
         });
 
@@ -18,10 +19,13 @@
 
             this.options = (typeof(opts.options) === 'string' ? opts.options.split(',') : opts.options || [])
                 .map(function(option) {
-                    return option.toString().trim();
+                    option = {
+                      value : (option.hasOwnProperty('value') ? option.value.toString().trim() : option.toString().trim()),
+                      label : (option.hasOwnProperty('label') ? option.label.toString().trim() : option.toString().trim())
+                    };
+                    return option;
                 });
 
-            this.refs.input.value = this.root.$value;
         });
 
     </script>


### PR DESCRIPTION
I added the functionality to use select fields with keys and labels in field-select and field-multipleselect.

Usage:

```json
{
  "options": [
    {
      "value": "a",
      "label": "one"
    },
    {
      "value": "b",
      "label": "two"
    }
  ]
}
```

It is backwards compatible, so `{"options": "a,b,c"}` or `{"options": ["a","b","c"]}` still work.

Only the values are stored - like before.

references:
#699
https://discourse.getcockpit.com/t/select-field-label-for-each-value/145