### PR TITLE
catch console error of jsoneditor if field object contains invalid json

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -2991,9 +2991,15 @@ riot.tag2('field-object', '<div ref="input" riot-style="height: {opts.height || 
                 editor = new JSONEditor(this.refs.input, {
                     modes: ['tree', 'code'],
                     mode: 'code',
-                    onChange: function(){
-                        $this.value = editor.get() || {};
-                        $this.$setValue($this.value, true);
+                    onError: function (e) {
+                        alert(e.toString());
+                    },
+                    onChange: function() {
+                        try {
+                            $this.value = editor.get() || {};
+                            $this.$setValue($this.value, true);
+                        }
+                        catch (e) {}
                     }
                 });
 

--- a/modules/Cockpit/assets/components/field-object.tag
+++ b/modules/Cockpit/assets/components/field-object.tag
@@ -27,9 +27,15 @@
                 editor = new JSONEditor(this.refs.input, {
                     modes: ['tree', 'code'],
                     mode: 'code',
-                    onChange: function(){
-                        $this.value = editor.get() || {};
-                        $this.$setValue($this.value, true);
+                    onError: function (e) {
+                        alert(e.toString());
+                    },
+                    onChange: function() {
+                        try {
+                            $this.value = editor.get() || {};
+                            $this.$setValue($this.value, true);
+                        }
+                        catch (e) {}
                     }
                 });
 


### PR DESCRIPTION
When the json in an object field is invalid (or empty string), each text
change fires a very long error message in the browser console.

The code editor still has a red "x", when it detects invalid content, so
there is no need for a custom console output (`catch (e) {}`).

`Error in onChange callback:  Error: Parse error on line 1: ...`

I found the solution here:
https://github.com/josdejong/jsoneditor/issues/413