### PR TITLE
moved order of defined constants to take care of COCKPIT_BASE_URL for api request

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -49,12 +49,12 @@ $COCKPIT_BASE_ROUTE  = $COCKPIT_BASE_URL;
  * SYSTEM DEFINES
  */
 if (!defined('COCKPIT_ADMIN'))                  define('COCKPIT_ADMIN'          , 0);
-if (!defined('COCKPIT_API_REQUEST'))            define('COCKPIT_API_REQUEST'    , COCKPIT_ADMIN && strpos($_SERVER['REQUEST_URI'], $COCKPIT_BASE_URL.'/api/')!==false ? 1:0);
+if (!defined('COCKPIT_BASE_URL'))               define('COCKPIT_BASE_URL'       , $COCKPIT_BASE_URL);
+if (!defined('COCKPIT_API_REQUEST'))            define('COCKPIT_API_REQUEST'    , COCKPIT_ADMIN && strpos($_SERVER['REQUEST_URI'], COCKPIT_BASE_URL.'/api/')!==false ? 1:0);
 if (!defined('COCKPIT_DIR'))                    define('COCKPIT_DIR'            , $COCKPIT_DIR);
 if (!defined('COCKPIT_SITE_DIR'))               define('COCKPIT_SITE_DIR'       , $COCKPIT_DIR == $COCKPIT_DOCS_ROOT ? $COCKPIT_DIR : dirname($COCKPIT_DIR));
 if (!defined('COCKPIT_CONFIG_DIR'))             define('COCKPIT_CONFIG_DIR'     , COCKPIT_DIR.'/config');
 if (!defined('COCKPIT_DOCS_ROOT'))              define('COCKPIT_DOCS_ROOT'      , $COCKPIT_DOCS_ROOT);
-if (!defined('COCKPIT_BASE_URL'))               define('COCKPIT_BASE_URL'       , $COCKPIT_BASE_URL);
 if (!defined('COCKPIT_BASE_ROUTE'))             define('COCKPIT_BASE_ROUTE'     , $COCKPIT_BASE_ROUTE);
 if (!defined('COCKPIT_STORAGE_FOLDER'))         define('COCKPIT_STORAGE_FOLDER' , COCKPIT_DIR.'/storage');
 if (!defined('COCKPIT_PUBLIC_STORAGE_FOLDER'))  define('COCKPIT_PUBLIC_STORAGE_FOLDER' , COCKPIT_DIR.'/storage');


### PR DESCRIPTION
If COCKPIT_BASE_URL was defined in defines.php for using Cockpit in a subfolder, the backend worked and the api calls redirected to login.

That happened, because COCKPIT_API_REQUEST was never set to '1' after comparing the auto-guessed $COCKPIT_BASE_URL instead of defined COCKPIT_BASE_URL.

Tested by me and @PilsFour an a shared host on strato.

fixes: #873
references: https://discourse.getcockpit.com/t/cant-access-api/221