### PR TITLE
mount opts in nested riot tags (fields: tags, colortag)

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -1942,8 +1942,15 @@ riot.tag2('field-color', '<input ref="input" class="uk-width-1-1" type="text">',
 riot.tag2('field-colortag', '<div class="uk-display-inline-block" data-uk-dropdown="pos:\'right-center\'"> <a riot-style="font-size:{size};color:{value || \'#ccc\'}"><i class="uk-icon-circle"></i></a> <div class="uk-dropdown uk-text-center"> <strong class="uk-text-small">{App.i18n.get(\'Choose\')}</strong> <div class="uk-grid uk-grid-small uk-margin-small-top uk-grid-width-1-4"> <div class="uk-grid-margin" each="{color in colors}"> <a onclick="{parent.select}" riot-style="color:{color};"><i class="uk-icon-circle"></i></a> </div> </div> <div class="uk-margin-top uk-text-small"> <a onclick="{reset}">{App.i18n.get(\'Reset\')}</a> </div> </div> </div>', '', '', function(opts) {
 
         this.value  = '';
-        this.size   = opts.size || 'inherit';
-        this.colors = opts.colors || ['#D8334A','#FFCE54','#A0D468','#48CFAD','#4FC1E9','#5D9CEC','#AC92EC','#EC87C0','#BAA286','#8E8271','#3C3B3D'];
+
+        this.on('mount',function(){
+            this.update();
+        });
+
+        this.on('update', function(){
+            this.size   = opts.size || 'inherit';
+            this.colors = opts.colors || ['#D8334A','#FFCE54','#A0D468','#48CFAD','#4FC1E9','#5D9CEC','#AC92EC','#EC87C0','#BAA286','#8E8271','#3C3B3D'];
+        });
 
         this.$updateValue = function(value, field) {
 
@@ -3466,6 +3473,10 @@ riot.tag2('field-tags', '<div class="uk-grid uk-grid-small uk-flex-middle" data-
         this._tags = [];
 
         this.on('mount', function(){
+            this.update()
+        });
+
+        this.on('update', function(){
 
             if (opts.autocomplete) {
 

--- a/modules/Cockpit/assets/components/field-colortag.tag
+++ b/modules/Cockpit/assets/components/field-colortag.tag
@@ -25,8 +25,15 @@
     <script>
 
         this.value  = '';
-        this.size   = opts.size || 'inherit';
-        this.colors = opts.colors || ['#D8334A','#FFCE54','#A0D468','#48CFAD','#4FC1E9','#5D9CEC','#AC92EC','#EC87C0','#BAA286','#8E8271','#3C3B3D'];
+
+        this.on('mount',function(){
+            this.update();
+        });
+
+        this.on('update', function(){
+            this.size   = opts.size || 'inherit';
+            this.colors = opts.colors || ['#D8334A','#FFCE54','#A0D468','#48CFAD','#4FC1E9','#5D9CEC','#AC92EC','#EC87C0','#BAA286','#8E8271','#3C3B3D'];
+        });
 
         this.$updateValue = function(value, field) {
 

--- a/modules/Cockpit/assets/components/field-tags.tag
+++ b/modules/Cockpit/assets/components/field-tags.tag
@@ -35,6 +35,10 @@
         this._tags = [];
 
         this.on('mount', function(){
+            this.update()
+        });
+
+        this.on('update', function(){
 
             if (opts.autocomplete) {
 


### PR DESCRIPTION
fixes: #900

related: https://discourse.getcockpit.com/t/reuse-core-fields-pass-opts-to-nested-riot-tags-with-inconsistent-mount-update-events/348