### PR TITLE
Mailer error handling

### DIFF
--- a/lib/Mailer.php
+++ b/lib/Mailer.php
@@ -34,7 +34,7 @@ class Mailer {
 
     public function createMessage($to, $subject, $message, $options=[]) {
 
-        $mail = new PHPMailer();
+        $mail = new PHPMailer(true);
 
         if ($this->transport == 'smtp') {
 

--- a/modules/Cockpit/views/layouts/forgotpassword.php
+++ b/modules/Cockpit/views/layouts/forgotpassword.php
@@ -53,6 +53,10 @@
                     <div class="uk-animation-shake uk-margin-top" if="{ error }">
                         <strong>{ error }</strong>
                     </div>
+
+                    <div class="uk-animation-shake uk-margin-top" if="{ message }">
+                        <strong>{ message }</strong>
+                    </div>
                 </div>
 
                 <div class="uk-alert uk-alert-success uk-text-center uk-animation-slide-bottom" if="{ reset }">
@@ -77,6 +81,7 @@
 
             this.error = false;
             this.reset = false;
+            this.message = false;
 
             submit(e) {
 
@@ -88,11 +93,12 @@
                 App.request('/auth/requestreset', {user:this.refs.user.value}).then(function(data){
 
                     this.reset = true;
+                    this.message = data.message;
                     this.update();
 
                 }.bind(this)).catch(function(data) {
 
-                    this.error = '@lang("User does not exist")';
+                    this.error = typeof data.error === 'string' ? data.error : '@lang("Something went wrong")';
 
                     App.$('#reset-dialog').removeClass('uk-animation-shake');
 

--- a/modules/Forms/bootstrap.php
+++ b/modules/Forms/bootstrap.php
@@ -296,7 +296,11 @@ $this->module('forms')->extend([
 
                 $formname = isset($frm['label']) && trim($frm['label']) ? $frm['label'] : $form;
 
-                $this->app->mailer->mail($frm['email_forward'], $options['subject'] ?? "New form data for: {$formname}", $body, $options);
+                try {
+                    $response = $this->app->mailer->mail($frm['email_forward'], $options['subject'] ?? "New form data for: {$formname}", $body, $options);
+                } catch (\Exception $e) {
+                    $response = $e->getMessage();
+                }
             }
         }
 
@@ -307,7 +311,7 @@ $this->module('forms')->extend([
 
         $this->app->trigger('forms.submit.after', [$form, &$data, $frm]);
 
-        return $data;
+        return (isset($response) && $response !== true) ? ['error' => $response, 'data' => $data] : $data;
     }
 ]);
 


### PR DESCRIPTION
Now the mailer throws errors and they are catched in forms/submit and in password reset.

I had some struggle with i18n of error messages on the password reset page with the mixup of LimeExtra and riot.js, so I translated the messages in Auth.php before sending the json string.