### PR TITLE
Fix $gte & $lte working like $gt & $lt

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -322,11 +322,18 @@ class UtilArrayQuery {
             case '$eq' :
                 $r = $a == $b;
                 break;
+
             case '$not' :
             case '$ne' :
                 $r = $a != $b;
                 break;
+
             case '$gte' :
+                if ( (is_numeric($a) && is_numeric($b)) || (is_string($a) && is_string($b)) ) {
+                    $r = $a >= $b;
+                }
+                break;
+
             case '$gt' :
                 if ( (is_numeric($a) && is_numeric($b)) || (is_string($a) && is_string($b)) ) {
                     $r = $a > $b;
@@ -334,11 +341,17 @@ class UtilArrayQuery {
                 break;
 
             case '$lte' :
+                if ( (is_numeric($a) && is_numeric($b)) || (is_string($a) && is_string($b)) ) {
+                    $r = $a <= $b;
+                }
+                break;
+
             case '$lt' :
                 if ( (is_numeric($a) && is_numeric($b)) || (is_string($a) && is_string($b)) ) {
                     $r = $a < $b;
                 }
                 break;
+
             case '$in' :
                 if (is_array($a)) {
                     $r = is_array($b) ? count(array_intersect($a, $b)) : false;


### PR DESCRIPTION
`$gte` should mean *greater than or equal to*, but now it is just alias of `$gt`. So it doesn't select equal values. The same problem is with `$lte` and `$lt`.