### PR TITLE
add libzip-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7-apache
 RUN apt-get update \
     && apt-get install -y \
 		wget zip unzip \
+        libzip-dev \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \


### PR DESCRIPTION
Because libzip error occurred during `$ npm run docker-init`, I added libzip-dev installation process to Dockerfile. As a result, this problem was resolved and the container was successfully built.

```
$ npm run docker-init
~
configure: error: Please reinstall the libzip distribution
The command '/bin/sh -c apt-get update     && apt-get install -y                wget zip unzip         libfreetype6-dev         libjpeg62-turbo-dev         libpng-dev         sqlite3 libsqlite3-dev         libssl-dev     && pecl install mongodb     && pecl install redis     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/     && docker-php-ext-install -j$(nproc) iconv gd pdo zip opcache pdo_sqlite     && a2enmod re
write expires' returned a non-zero code: 1
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! cockpit-next@0.8.7 docker-init: `docker build -t cockpit/dev .`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the cockpit-next@0.8.7 docker-init script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/Nori/.npm/_logs/2019-01-27T00_51_11_410Z-debug.log
```

