### PR TITLE
fix(image-thumbnails): re-enable filter 'edge detect' (bc)

### DIFF
--- a/modules/Cockpit/bootstrap.php
+++ b/modules/Cockpit/bootstrap.php
@@ -262,9 +262,18 @@ $this->module('cockpit')->extend([
 
                 // Apply single filter
                 foreach ($_filters as $f) {
+                    $filterName = $f;
+                    // fix filters with spaces
+                    if (strpos($filterName, ' ') !== false) {
+                        $parts = explode(' ', $filterName);
+                        for ($i = 1; $i < count($parts); $i++) {
+                            $parts[$i] = ucfirst($parts[$i]);
+                        }
+                        $filterName = implode('', $parts);
+                    }
 
                     if (isset($options[$f])) {
-                        $img->{$f}($options[$f]);
+                        $img->{$filterName}($options[$f]);
                     }
                 }
 


### PR DESCRIPTION
The method `edge detect` does not exist. This PR fixes all future method names with a space in between.
```
Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'claviska\SimpleImage' does not have a method 'edge detect' in /var/www/modules/Cockpit/bootstrap.php on line 271
```

See for proof of concept: https://3v4l.org/ZcJOG