### PR TITLE
Fixes collection-link display in Collection view

### DIFF
--- a/modules/Collections/assets/link-collectionitem.js
+++ b/modules/Collections/assets/link-collectionitem.js
@@ -35,10 +35,14 @@
         }
 
         setTimeout(() => {
-            linkCache[v._id].then(display => document.getElementById(v._id).innerText = display)
+            linkCache[v._id].then(display => {
+                for (let vClass of document.getElementsByClassName(v._id)) {
+                    vClass.innerText = display;
+                }
+            })
         });
 
-        return `<span id="${v._id}"><i class="uk-icon-spin uk-icon-spinner uk-text-muted"></i></span>`;
+        return `<span class="${v._id}"><i class="uk-icon-spin uk-icon-spinner uk-text-muted"></i></span>`;
     };
 
     function selectCollectionItem(fn, options) {


### PR DESCRIPTION
It uses same ID for more than one record and crashes visualization:

![image](https://user-images.githubusercontent.com/3215516/52852264-c7a98180-3120-11e9-8871-62410ed62ad9.png)


Changed to use ClassName instead