### PR TITLE
Prevent Catastrophic error by making registerModule check if bootstrap.php exists

### DIFF
--- a/lib/Lime/App.php
+++ b/lib/Lime/App.php
@@ -1278,6 +1278,9 @@ class App implements \ArrayAccess {
             $module = new Module($this);
 
             $module->_dir      = $dir;
+            
+            /* return false if no bootstrap.php file exists */
+            if(!file_exists("{$dir}/bootstrap.php")){return false;}
             $module->_bootfile = "{$dir}/bootstrap.php";
 
             $this->path($name, $dir);
@@ -1309,7 +1312,8 @@ class App implements \ArrayAccess {
 
                     if ($disabled && in_array($name, $disabled)) continue;
 
-                    $this->registerModule($name, $module->getRealPath());
+                    /* skip loading the module if registerModule returns false */
+                    if ( $this->registerModule($name, $module->getRealPath()) === false ) continue;
 
                     $modules[] = strtolower($module);
                 }


### PR DESCRIPTION
Prevent Catastrophic failure in `lib/Lime/App.php` by making registerModule check if bootstrap.php exists. See issue #1014 

### Proposed Fix
- make registerModule return false if no bootstrap.php file exits:
line 1281
```
            /* return false if no bootstrap.php file exists */
            if(!file_exists("{$dir}/bootstrap.php")){return false;}
            $module->_bootfile = "{$dir}/bootstrap.php";
```

- make loadModules skip the dir if registerModule returns false
line 1312 (<-- prior to above fix line 1315 after)
```
                    /* skip loading the module if registerModule returns false */
                    if ( $this->registerModule($name, $module->getRealPath()) === false ) continue;

```

