### PR TITLE
#1034 - support for meta

### DIFF
--- a/modules/Cockpit/Controller/RestApi.php
+++ b/modules/Cockpit/Controller/RestApi.php
@@ -228,8 +228,7 @@ class RestApi extends \LimeExtra\Controller {
     }
 
     public function addAssets() {
-
-        return $this->module('cockpit')->uploadAssets('files');
+        return $this->module('cockpit')->uploadAssets('files', $this->param('meta', []));
     }
 
     public function updateAssets() {

--- a/modules/Cockpit/module/assets.php
+++ b/modules/Cockpit/module/assets.php
@@ -29,7 +29,7 @@ $this->module('cockpit')->extend([
         $assets    = [];
         $created   = time();
 
-        foreach ($files as &$file) {
+        foreach ($files as $idx => &$file) {
 
             // clean filename
             $name = basename($file);
@@ -82,6 +82,10 @@ $this->module('cockpit')->extend([
             }
 
             $opts = ['mimetype' => $asset['mime']];
+
+            if (isset($meta[$idx]) && is_array($meta[$idx])) {
+                $meta = $meta[$idx];
+            }
 
             $this->app->trigger('cockpit.asset.upload', [&$asset, &$meta, &$opts]);
             if (!$asset) {

--- a/modules/Cockpit/module/assets.php
+++ b/modules/Cockpit/module/assets.php
@@ -83,9 +83,7 @@ $this->module('cockpit')->extend([
 
             $opts = ['mimetype' => $asset['mime']];
 
-            if (isset($meta[$idx]) && is_array($meta[$idx])) {
-                $meta = $meta[$idx];
-            }
+            $asset_meta = isset($meta[$idx]) && is_array($meta[$idx]) ? $meta[$idx] : $meta;
 
             $this->app->trigger('cockpit.asset.upload', [&$asset, &$meta, &$opts]);
             if (!$asset) {
@@ -97,7 +95,7 @@ $this->module('cockpit')->extend([
             $this->app->filestorage->writeStream("assets://{$path}", $stream, $opts);
             fclose($stream);
 
-            foreach ($meta as $key => $val) {
+            foreach ($asset_meta as $key => $val) {
                 $asset[$key] = $val;
             }
 


### PR DESCRIPTION
That should provide meta on api requests and therefore define meta fields (e.g. title, description, folder) during the asset creation using the api, e.g.:

![image](https://user-images.githubusercontent.com/102261/53413013-d4e92a80-39c2-11e9-8aeb-62daba9e8273.png)
