### PR TITLE
Tinymce fixes

### DIFF
--- a/modules/Cockpit/assets/cockpit.js
+++ b/modules/Cockpit/assets/cockpit.js
@@ -51,11 +51,11 @@
 
                 var selected = [], dialog = UIkit.modal.dialog([
                     '<div>',
-                        '<div class="uk-modal-header uk-text-large">Select file</div>',
+                        '<div class="uk-modal-header uk-text-large">'+App.i18n.get('Select file')+'</div>',
                         '<cp-finder path="'+(options.path || '')+'" typefilter="'+(options.typefilter || '')+'" modal="true"></cp-finder>',
                         '<div class="uk-modal-footer uk-text-right">',
-                            '<button class="uk-button uk-button-primary uk-margin-right uk-button-large uk-hidden js-select-button">Select: <span></span> item(s)</button>',
-                            '<a class="uk-button uk-button-large uk-button-link uk-modal-close">Close</a>',
+                            '<button class="uk-button uk-button-primary uk-margin-right uk-button-large uk-hidden js-select-button">'+App.i18n.get('Select')+': <span></span> item(s)</button>',
+                            '<a class="uk-button uk-button-large uk-button-link uk-modal-close">'+App.i18n.get('Close')+'</a>',
                         '</div>',
                     '</div>'
                 ].join(''), {modal:false});
@@ -105,11 +105,11 @@
 
                 var selected = [], dialog = UIkit.modal.dialog([
                     '<div>',
-                        '<div class="uk-modal-header uk-text-large">Select asset</div>',
+                        '<div class="uk-modal-header uk-text-large">'+App.i18n.get('Select asset')+'</div>',
                         '<cp-assets path="'+(options.path || '')+'" typefilter="'+(options.typefilter || '')+'" modal="true"></cp-assets>',
                         '<div class="uk-modal-footer uk-text-right">',
-                            '<button class="uk-button uk-button-primary uk-margin-right uk-button-large uk-hidden js-select-button">Select: <span></span> item(s)</button>',
-                            '<a class="uk-button uk-button-large uk-button-link uk-modal-close">Close</a>',
+                            '<button class="uk-button uk-button-primary uk-margin-right uk-button-large uk-hidden js-select-button">'+App.i18n.get('Select')+': <span></span> item(s)</button>',
+                            '<a class="uk-button uk-button-large uk-button-link uk-modal-close">'+App.i18n.get('Close')+'</a>',
                         '</div>',
                     '</div>'
                 ].join(''), {modal:false});

--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -3790,7 +3790,7 @@ riot.tag2('field-time', '<input ref="input" class="uk-width-1-1" bind="{opts.bin
 riot.tag2('field-wysiwyg', '<textarea ref="input" class="uk-width-1-1" rows="5" style="height:350px;visibility:hidden;"></textarea>', '', '', function(opts) {
 
         var $this     = this,
-            lang      = document.documentElement.getAttribute('lang') || 'en',
+            lang      = App.$data.user.i18n || document.documentElement.getAttribute('lang') || 'en',
             languages = ['ar','az','ba','bg','by','ca','cs','da','de','el','eo','es_ar','es','fa','fi','fr','ge','he','hr','hu','id','it','ja','ko','lt','lv','mk','nl','no_NB','pl','pt_br','pt_pt','ro','ru','sl','sq','sr-cir','sr-lat','sv','th','tr','ua','vi','zh_cn','zh_tw'],
             editor;
 
@@ -3810,6 +3810,10 @@ riot.tag2('field-wysiwyg', '<textarea ref="input" class="uk-width-1-1" rows="5" 
         }.bind(this);
 
         this.on('mount', function(){
+
+            if (opts.editor && opts.editor.language) {
+                lang = opts.editor.language;
+            }
 
             if (opts.cls) {
                 App.$(this.refs.input).addClass(opts.cls);
@@ -3840,6 +3844,8 @@ riot.tag2('field-wysiwyg', '<textarea ref="input" class="uk-width-1-1" rows="5" 
                         if (!App.$('#'+this.refs.input.id).length) return;
 
                         tinymce.init(App.$.extend(true, {
+                            language: lang,
+                            language_url : lang == 'en' ? '' : App.route('/config/cockpit/i18n/tinymce/'+lang+'.js'),
                             branding: false,
                             resize: true,
                             height: 350,

--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -3919,7 +3919,7 @@ riot.tag2('field-wysiwyg', '<textarea ref="input" class="uk-width-1-1" rows="5" 
 
                     editor.addMenuItem('mediapath', {
                         icon: 'image',
-                        text: 'Insert image (Finder)',
+                        text: App.i18n.get('Insert image (Finder)'),
                         onclick: function(){
 
                             App.media.select(function(selected) {
@@ -3937,7 +3937,7 @@ riot.tag2('field-wysiwyg', '<textarea ref="input" class="uk-width-1-1" rows="5" 
 
                 editor.addMenuItem('assetpath', {
                     icon: 'image',
-                    text: 'Insert Asset (Assets)',
+                    text: App.i18n.get('Insert Asset (Assets)'),
                     onclick: function(){
 
                         App.assets.select(function(assets){

--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -3846,7 +3846,8 @@ riot.tag2('field-wysiwyg', '<textarea ref="input" class="uk-width-1-1" rows="5" 
                             menubar: 'edit insert view format table tools',
                             plugins: [
                                 "link image lists preview hr anchor",
-                                "code fullscreen media mediapath",
+                                "code fullscreen media mediapath assetpath",
+                                "pageurl",
                                 "table contextmenu paste"
                             ],
                             relative_urls: false
@@ -3923,6 +3924,10 @@ riot.tag2('field-wysiwyg', '<textarea ref="input" class="uk-width-1-1" rows="5" 
                         prependToContext: true
                     });
                 }
+
+            });
+
+            tinymce.PluginManager.add('assetpath', function(editor) {
 
                 editor.addMenuItem('assetpath', {
                     icon: 'image',

--- a/modules/Cockpit/assets/components/field-wysiwyg.tag
+++ b/modules/Cockpit/assets/components/field-wysiwyg.tag
@@ -62,7 +62,8 @@
                             menubar: 'edit insert view format table tools',
                             plugins: [
                                 "link image lists preview hr anchor",
-                                "code fullscreen media mediapath",
+                                "code fullscreen media mediapath assetpath",
+                                "pageurl", // collection-link
                                 "table contextmenu paste"
                             ],
                             relative_urls: false
@@ -141,6 +142,10 @@
                         prependToContext: true
                     });
                 }
+
+            });
+
+            tinymce.PluginManager.add('assetpath', function(editor) {
 
                 editor.addMenuItem('assetpath', {
                     icon: 'image',

--- a/modules/Cockpit/assets/components/field-wysiwyg.tag
+++ b/modules/Cockpit/assets/components/field-wysiwyg.tag
@@ -137,7 +137,7 @@
                     
                     editor.addMenuItem('mediapath', {
                         icon: 'image',
-                        text: 'Insert image (Finder)',
+                        text: App.i18n.get('Insert image (Finder)'),
                         onclick: function(){
 
                             App.media.select(function(selected) {
@@ -155,7 +155,7 @@
 
                 editor.addMenuItem('assetpath', {
                     icon: 'image',
-                    text: 'Insert Asset (Assets)',
+                    text: App.i18n.get('Insert Asset (Assets)'),
                     onclick: function(){
 
                         App.assets.select(function(assets){

--- a/modules/Cockpit/assets/components/field-wysiwyg.tag
+++ b/modules/Cockpit/assets/components/field-wysiwyg.tag
@@ -5,7 +5,7 @@
     <script>
 
         var $this     = this,
-            lang      = document.documentElement.getAttribute('lang') || 'en',
+            lang      = App.$data.user.i18n || document.documentElement.getAttribute('lang') || 'en',
             languages = ['ar','az','ba','bg','by','ca','cs','da','de','el','eo','es_ar','es','fa','fi','fr','ge','he','hr','hu','id','it','ja','ko','lt','lv','mk','nl','no_NB','pl','pt_br','pt_pt','ro','ru','sl','sq','sr-cir','sr-lat','sv','th','tr','ua','vi','zh_cn','zh_tw'],
             editor;
 
@@ -26,6 +26,10 @@
 
 
         this.on('mount', function(){
+
+            if (opts.editor && opts.editor.language) {
+                lang = opts.editor.language;
+            }
 
             if (opts.cls) {
                 App.$(this.refs.input).addClass(opts.cls);
@@ -56,6 +60,8 @@
                         if (!App.$('#'+this.refs.input.id).length) return;
 
                         tinymce.init(App.$.extend(true, {
+                            language: lang,
+                            language_url : lang == 'en' ? '' : App.route('/config/cockpit/i18n/tinymce/'+lang+'.js'),
                             branding: false,
                             resize: true,
                             height: 350,

--- a/modules/Collections/assets/link-collectionitem.js
+++ b/modules/Collections/assets/link-collectionitem.js
@@ -101,7 +101,7 @@
 
             ed.addMenuItem('pageurl', {
                 icon: 'link',
-                text: 'Link Collection Item',
+                text: App.i18n.get('Link Collection Item'),
                 onclick: function(){
 
                     selectCollectionItem(function(data){

--- a/modules/Collections/assets/link-collectionitem.js
+++ b/modules/Collections/assets/link-collectionitem.js
@@ -97,17 +97,21 @@
 
     App.$(document).on('init-wysiwyg-editor', function(e, editor){
 
-        editor.addMenuItem('pageurl', {
-            icon: 'link',
-            text: 'Link Collection Item',
-            onclick: function(){
+        tinymce.PluginManager.add('pageurl', function(ed) {
 
-                selectCollectionItem(function(data){
-                    editor.insertContent('<a href="' + data.url + '" alt="">'+data.title+'</a>');
-                }, {url:'',title:''});
-            },
-            context: 'insert',
-            prependToContext: true
+            ed.addMenuItem('pageurl', {
+                icon: 'link',
+                text: 'Link Collection Item',
+                onclick: function(){
+
+                    selectCollectionItem(function(data){
+                        ed.insertContent('<a href="' + data.url + '" alt="">'+data.title+'</a>');
+                    }, {url:'',title:''});
+                },
+                context: 'insert',
+                prependToContext: true
+            });
+
         });
 
     });


### PR DESCRIPTION
* added functionality to disable tinymce plugins - now pageurl, assetpath and mediapath are available as separate plugins --> Works also with https://github.com/pauloamgomes/CockpitCms-EditorFormats
* added i18n for tinymce - copy i18n file into `config/cockpit/i18n/tinymce/de.js`