### PR TITLE
Allows getting the value at path of object in field-collectionlink

### DIFF
--- a/modules/Collections/assets/field-collectionlink.tag
+++ b/modules/Collections/assets/field-collectionlink.tag
@@ -228,11 +228,12 @@
 
     linkItem(e) {
 
+        var defaultField = this.collection.fields[0].name;
         var _entry = e.item.entry;
         var entry = {
             _id: _entry._id,
             link: this.collection.name,
-            display: _entry[opts.display] || _entry[this.collection.fields[0].name] || 'n/a'
+            display: _.get(_entry, opts.display) || typeof _entry[defaultField] === 'string' && _entry[defaultField] || 'n/a'
         };
 
         if (opts.multiple) {
@@ -273,11 +274,12 @@
 
         this.selected.forEach(function(_entry) {
             
+            var defaultField = $this.collection.fields[0].name;
             cache[_entry._id] = _entry;
             entry = {
                 _id: _entry._id,
                 link: $this.collection.name,
-                display: _entry[opts.display] || _entry[$this.collection.fields[0].name] || 'n/a'
+                display: _.get(_entry, opts.display) || typeof _entry[defaultField] === 'string' && _entry[defaultField] || 'n/a'
             };
 
             $this.link.push(entry);


### PR DESCRIPTION
This enables us to get a proper name when linking to a collection having a set-like field or an asset field for example.
This replicates the behaviour seen in field-repeater.
What do you think ?