### PR TITLE
[WIP] Add number field

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -3212,6 +3212,21 @@ riot.tag2('field-multipleselect', '<div class="{options.length > 10 ? \'uk-scrol
 
 });
 
+riot.tag2('field-number', '<div class="uk-position-relative field-number-container"> <input ref="input" class="uk-width-1-1" bind="{opts.bind}" placeholder="{opts.placeholder}" type="number"> </div>', '', '', function(opts) {
+        this.on('mount', function() {
+
+            opts.cls && App.$(this.refs.input).addClass(opts.cls);
+
+            opts.required && this.refs.input.setAttribute('required', 'required');
+
+            ['max', 'min', 'placeholder', 'readonly', 'step'].forEach( function(key) {
+                opts[key] && this.refs.input.setAttribute(key, opts[key]);
+            }.bind(this));
+
+            this.update();
+        });
+});
+
 riot.tag2('field-object', '<div ref="input" riot-style="height: {opts.height || \'300px\'}"></div>', '', '', function(opts) {
 
         var $this = this, editor;

--- a/modules/Cockpit/assets/components/field-number.tag
+++ b/modules/Cockpit/assets/components/field-number.tag
@@ -1,0 +1,20 @@
+<field-number>
+    <div class="uk-position-relative field-number-container">
+        <input ref="input" class="uk-width-1-1" bind="{opts.bind}" type="number"  placeholder="{opts.placeholder}">
+    </div>
+
+    <script>
+        this.on('mount', function() {
+
+            opts.cls && App.$(this.refs.input).addClass(opts.cls);
+
+            opts.required && this.refs.input.setAttribute('required', 'required');
+
+            ['max', 'min', 'placeholder', 'readonly', 'step'].forEach( function(key) {
+                opts[key] && this.refs.input.setAttribute(key, opts[key]);
+            }.bind(this));
+
+            this.update();
+        });
+    </script>
+</field-number>

--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -8,7 +8,7 @@
 @endif
 
 <script>
-    window.__collectionEntry = {{ json_encode($entry) }};
+    window.__collectionEntry = {{ json_encode($entry, JSON_NUMERIC_CHECK) }};
 </script>
 
 <div>


### PR DESCRIPTION
WIP - Please don't merge @aheinze.

This PR adds explicit `number` field. I'm aware of the option to use `text` field for this purpose (by adding `"type": "number"` in options (related discussions: [link 1](https://discourse.getcockpit.com/t/number-field-type/393/2), [link 2](https://github.com/agentejo/cockpit/issues/822#issuecomment-458880616)).
The issue I'm facing with current solution is that, even though the UI recognizes the type number field and renders appropriate input tag, the actual value gets converted in 2 places from number to string.
First (implicit conversion) happens when doing JSON serialization [here](https://github.com/agentejo/cockpit/blob/next/modules/Collections/views/entry.php#L11), and the second (explicit) one just before saving [here](https://github.com/agentejo/cockpit/blob/next/modules/Collections/bootstrap.php#L302).
Also, it seems that @aheinze  already had this use case in mind judging by [this commit](https://github.com/agentejo/cockpit/commit/4a9057541de1b557bdc92e9ea1497a3609732d16) and [this comment](https://discourse.getcockpit.com/t/api-returns-int-for-text-value/366/8).

So it seems that we have 2 options, either to fix this return type or to switch to having explicit `number` field type (this PR). Pro of the first approach is that it would be less code (probably could be done with one line surgically in particular place). Pros of the second approach are, even though we end up with more code, we have benefit of transparency (the whole discussion from link 1 and link 2 above wouldn't be happening in the future) and by not casting values (especially in multiple places) we would avoid source of subtle bugs (it took me a while to figure out why my sort function on one of the "number" fields didn't give expected results on the frontend before I realize that it wasn't sorting by number values but by ASCII string values!).
Finally, should we decide to go this route we'll have to consider plugins support. For example, CockpitQL would have to update it's [types list](https://github.com/agentejo/CockpitQL/blob/master/Types/FieldType.php#L37-L49) before it could work with the new number field.
 
Related issue: #1062 