### PR TITLE
Improve custom form validation response message

### DIFF
--- a/modules/Forms/bootstrap.php
+++ b/modules/Forms/bootstrap.php
@@ -260,8 +260,8 @@ $this->module('forms')->extend([
         }
 
         // custom form validation
-        if ($this->app->path("#config:forms/{$form}.php") && false===include($this->app->path("#config:forms/{$form}.php"))) {
-            return false;
+        if ($this->app->path("#config:forms/{$form}.php") && true!==$validation=include($this->app->path("#config:forms/{$form}.php"))) {
+            return false===$validation ? false : ['error' => $validation, 'data' => $data];
         }
 
         $this->app->trigger('forms.submit.before', [$form, &$data, $frm, &$options]);


### PR DESCRIPTION
Currently when adding custom form validation as described in the docs you can only return false if a certain field fails validation.

```php
if ($data["field1"] != "value1") {
    return false;
}

return true;
```

This pull request would allow you to return a custom validation error message like so:

```php
if ($data["field1"] != "value1") {
    return "Field1 did not have the correct value, please try again.";
}

return true;
```

This allows you to display this error message on the client side and give a user more information on why the form failed validation.

I added the conditional `return false===$validation ? false : ['error' => $validation, 'data' => $data];` so that this change will not be breaking for anyone still using the current validation response.