### PR TITLE
During installation, create missing folders when possible.

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -21,7 +21,7 @@ function ensure_writable($path) {
         $dir = COCKPIT_STORAGE_FOLDER.$path;
         $exists = file_exists($dir);
         if (!$exists) {
-            mkdir($dir, 0777, TRUE);
+            mkdir($dir, 0700, TRUE);
             if ($path === '/data') {
                 $file = $dir.'/.htaccess';
                 file_put_contents($file, 'deny from all');

--- a/install/index.php
+++ b/install/index.php
@@ -41,10 +41,10 @@ $checks = array(
     'Missing PDO extension with Sqlite support'         => $sqlitesupport,
     'GD extension not available'                        => extension_loaded('gd'),
     'MBString extension not available'                  => extension_loaded('mbstring'),
-    'Data  folder is not writable: /storage/data'       => ensure_writable('/data'),
+    'Data folder is not writable: /storage/data'        => ensure_writable('/data'),
     'Cache folder is not writable: /storage/cache'      => ensure_writable('/cache'),
     'Temp folder is not writable: /storage/tmp'         => ensure_writable('/tmp'),
-    'Thumbs  folder is not writable: /storage/thumbs'   => ensure_writable('/thumbs'),
+    'Thumbs folder is not writable: /storage/thumbs'    => ensure_writable('/thumbs'),
     'Uploads folder is not writable: /storage/uploads'  => ensure_writable('/uploads'),
 );
 

--- a/install/index.php
+++ b/install/index.php
@@ -16,17 +16,36 @@ try {
 
 require(__DIR__.'/../bootstrap.php');
 
+function ensure_writable($path) {
+    try {
+        $dir = COCKPIT_STORAGE_FOLDER.$path;
+        $exists = file_exists($dir);
+        if (!$exists) {
+            mkdir($dir, 0777, TRUE);
+            if ($path === '/data') {
+                $file = $dir.'/.htaccess';
+                file_put_contents($file, 'deny from all');
+                if (!file_exists($file)) return false;
+            }
+        }
+        return is_writable($dir);
+    } catch (Exception $e) {
+        error_log($e);
+        return false;
+    }
+}
+
 // misc checks
 $checks = array(
     'Php version >= 7.1.0'                              => (version_compare(PHP_VERSION, '7.1.0') >= 0),
     'Missing PDO extension with Sqlite support'         => $sqlitesupport,
     'GD extension not available'                        => extension_loaded('gd'),
     'MBString extension not available'                  => extension_loaded('mbstring'),
-    'Data folder is not writable: /storage/data'       => is_writable(COCKPIT_STORAGE_FOLDER.'/data'),
-    'Cache folder is not writable: /storage/cache'      => is_writable(COCKPIT_STORAGE_FOLDER.'/cache'),
-    'Temp folder is not writable: /storage/tmp'         => is_writable(COCKPIT_STORAGE_FOLDER.'/tmp'),
-    'Thumbs folder is not writable: /storage/thumbs'         => is_writable(COCKPIT_STORAGE_FOLDER.'/thumbs'),
-    'Uploads folder is not writable: /storage/uploads'  => is_writable(COCKPIT_STORAGE_FOLDER.'/uploads'),
+    'Data  folder is not writable: /storage/data'       => ensure_writable('/data'),
+    'Cache folder is not writable: /storage/cache'      => ensure_writable('/cache'),
+    'Temp folder is not writable: /storage/tmp'         => ensure_writable('/tmp'),
+    'Thumbs  folder is not writable: /storage/thumbs'   => ensure_writable('/thumbs'),
+    'Uploads folder is not writable: /storage/uploads'  => ensure_writable('/uploads'),
 );
 
 $failed = [];


### PR DESCRIPTION
Awhile ago, I encountered an issue when attempting to use cockpit in a containerized environment. If some folder(s) did not exist before initiating installation, the install would be unable to proceed. This update allowed us to run through the cockpit install despite mounting a totally empty volume.