### PR TITLE
Asset upoad from CloudStorage plugin cannot close stream

### DIFF
--- a/modules/Cockpit/module/assets.php
+++ b/modules/Cockpit/module/assets.php
@@ -97,7 +97,9 @@ $this->module('cockpit')->extend([
             // move file
             $stream = fopen($file, 'r+');
             $this->app->filestorage->writeStream("assets://{$path}", $stream, $opts);
-            fclose($stream);
+            if(is_resource($stream)) {
+                fclose($stream);
+            }
 
             foreach ($_meta as $key => $val) {
                 $asset[$key] = $val;


### PR DESCRIPTION
When uploading an asset to google cloud storage, the stream cannot be closed.
The simplest solution is to only close stream if it is a resource.

This is needed to make https://github.com/agentejo/CloudStorage/pull/6 not give frontend error messages when uploading an asset.