### PR TITLE
Fix Call to undefined function levenshtein_utf8()

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -486,7 +486,7 @@ function fuzzy_search($search, $text, $distance = 3){
                 $score += 1;
             } else {
 
-                $d = \levenshtein_utf8($needle, $token);
+                $d = levenshtein_utf8($needle, $token);
 
                 if ($d <= $distance) {
                     $l       = \mb_strlen($token, 'UTF-8');


### PR DESCRIPTION
When using $fuzzy/ $text filters, error comes up:
```
Error: Call to undefined function levenshtein_utf8()
```

This is because _levenshtein_utf8_ is not a global function and should not be called via `\levenshtein_utf8()`

Bug was introduced in 411ec6e8e6