### PR TITLE
Fix php 7.2 deprecation notice in $mod filter

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -406,7 +406,7 @@ class UtilArrayQuery {
             case '$mod' :
                 if (! \is_array($b))
                     throw new \InvalidArgumentException('Invalid argument for $mod option must be array');
-                list($x, $y) = each($b);
+                $x = array_keys($b)[0];
                 $r = $a % $x == 0;
                 break;
 


### PR DESCRIPTION
When using mod filter, deprecation message comes up:
```
The each() function is deprecated. This message will be suppressed on further calls
```
This is because `each` has been [deprecated in php 7.2](https://www.php.net/each)