### PR TITLE
Fix $mod arguments

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -406,8 +406,7 @@ class UtilArrayQuery {
             case '$mod' :
                 if (! \is_array($b))
                     throw new \InvalidArgumentException('Invalid argument for $mod option must be array');
-                $x = array_keys($b)[0];
-                $r = $a % $x == 0;
+                $r = $a % $b[0] == $b[1] ?? 0;
                 break;
 
             case '$func' :


### PR DESCRIPTION
At this moment $mod arguments signature in MongoLite driver is
```
['$mod' => [<divisor> => <ignored>]]
```

As per [MongoDB docs](https://docs.mongodb.com/manual/reference/operator/query/mod/) it should be 
```
['$mod' => [<divisor>, <remainder>]]
```

while remainder is required, I've used fall back to 0