### PR TITLE
Remove collection from cache after it's been dropped (MongoLite)

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -163,6 +163,9 @@ class Database {
      */
     public function dropCollection($name) {
         $this->connection->exec("DROP TABLE `{$name}`");
+
+        // Remove collection from cache
+        unset($this->collections[$name]);
     }
 
     /**


### PR DESCRIPTION
At this moment after collection is dropped, it's still present in cached array

Test case
```php
$app->storage->getCollection('collections/foobar');
$app->storage->dropCollection('collections/foobar');
$app->storage->count('collections/foobar');
```

Throws an error because there is a _SELECT_ query being run on table which doesn't exist
and was not being created in Database::selectCollection as it's still in cache array
```
Error: Call to a member function fetch() on bool

lib/MongoLite/Cursor.php:94
```