### PR TITLE
Fix $not operator (MongoLite)

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -394,7 +394,11 @@ class UtilArrayQuery {
             case '$regex' :
             case '$preg' :
             case '$match' :
+            case '$not':
                 $r = (boolean) @\preg_match(isset($b[0]) && $b[0]=='/' ? $b : '/'.$b.'/iu', $a, $match);
+                if ($func === '$not') {
+                    $r = !$r;
+                }
                 break;
 
             case '$size' :

--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -333,7 +333,6 @@ class UtilArrayQuery {
                 $r = $a == $b;
                 break;
 
-            case '$not' :
             case '$ne' :
                 $r = $a != $b;
                 break;


### PR DESCRIPTION
As per [MongoDb Docs](https://docs.mongodb.com/manual/reference/operator/query/not/) `$not` operator isn't the same as `$neq`.

I've added the Regular expression functionality via `$regexp`

#### via Regular expression
```php
$app->storage->findOne('collections/test', 
    // When using MongoHybrid\MongoLite driver
    'content' => ['$not' => 'Lorem .*'],
    // When using MongoHybrid\Client driver
    // 'content' => ['$not' => new \MongoDB\BSON\Regex('Lorem .*')],
]);
```

#### via Operator (not implemented, for reference)
```php
$app->storage->findOne('collections/test', 
    'content' => ['$not' => ['$eq' => 'Lorem ipsum']],
]);
```