### PR TITLE
Fix SQLite DSN when using :memory: as a path

### DIFF
--- a/lib/MongoLite/Client.php
+++ b/lib/MongoLite/Client.php
@@ -44,18 +44,21 @@ class Client {
     /**
      * List Databases
      *
-     * @return array List of databases
+     * @return array List of database names
      */
     public function listDBs() {
 
+        // Return all databases available in memory
+        if ($this->path === Database::DSN_PATH_MEMORY) {
+            return array_keys($this->databases);
+        }
+
+        // Return all databases available on disk
         $databases = [];
 
-        // Skip when using :memory: as path
-        if (is_dir($this->path)) {
-            foreach (new \DirectoryIterator($this->path) as $fileInfo) {
-                if ($fileInfo->getExtension() === 'sqlite') {
-                    $databases[] = $fileInfo->getBasename('.sqlite');
-                }
+        foreach (new \DirectoryIterator($this->path) as $fileInfo) {
+            if ($fileInfo->getExtension() === 'sqlite') {
+                $databases[] = $fileInfo->getBasename('.sqlite');
             }
         }
 
@@ -67,7 +70,7 @@ class Client {
      *
      * @param  string $database
      * @param  string $collection
-     * @return object
+     * @return Collection
      */
     public function selectCollection($database, $collection) {
 
@@ -78,13 +81,13 @@ class Client {
      * Select database
      *
      * @param  string $name
-     * @return object
+     * @return Database
      */
     public function selectDB($name) {
 
         if (!isset($this->databases[$name])) {
             $this->databases[$name] = new Database(
-                $this->path === ':memory:' ? $this->path : sprintf('%s/%s.sqlite', $this->path, $name),
+                $this->path === Database::DSN_PATH_MEMORY ? $this->path : sprintf('%s/%s.sqlite', $this->path, $name),
                 $this->options
             );
         }

--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -16,6 +16,11 @@ namespace MongoLite;
 class Database {
 
     /**
+     * @var string - DSN path form memory database
+     */
+    public const DSN_PATH_MEMORY = ':memory:';
+
+    /**
      * @var PDO object
      */
     public $connection;
@@ -35,14 +40,13 @@ class Database {
      */
     protected $document_criterias = [];
 
-
     /**
      * Constructor
      *
      * @param string $path
      * @param array  $options
      */
-    public function __construct($path = ":memory:", $options = []) {
+    public function __construct($path = self::DSN_PATH_MEMORY, $options = []) {
 
         $dns = "sqlite:{$path}";
 
@@ -142,7 +146,7 @@ class Database {
      * Drop database
      */
     public function drop() {
-        if ($this->path != ':memory:') {
+        if ($this->path != static::DSN_PATH_MEMORY) {
             \unlink($this->path);
         }
     }


### PR DESCRIPTION
At the moment when using database server setting `mongolite://:memory:`, MongoLite Client creates new Database in format `:memory:/collectionName.sqlite` which throws PDOException.

I've changed the behavior to not append collection name when path is _:memory:_.
Created databases are still available in cache (_Client::$databases_) and it's possible to list them via _Client::listDBs()_ method

Fixing the _:memory:_ path this helps with creating tests for MongoLite driver.