### PR TITLE
Missing settings event in forms module

### DIFF
--- a/modules/Forms/views/form.php
+++ b/modules/Forms/views/form.php
@@ -74,10 +74,6 @@
 
             </div>
 
-            <div class="uk-width-medium-1-2">
-
-            </div>
-
         </div>
 
         <cp-actionbar>

--- a/modules/Forms/views/form.php
+++ b/modules/Forms/views/form.php
@@ -70,6 +70,8 @@
                     <field-boolean bind="form.save_entry" label="@lang('Save form data')"></field-boolean>
                 </div>
 
+                @trigger('forms.settings.aside')
+
             </div>
 
             <div class="uk-width-medium-1-2">


### PR DESCRIPTION
added forms.settings.aside event to enable the in_menu feature