### PR TITLE
Use overriden default language in "Copy content from"

### DIFF
--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -97,7 +97,7 @@
                                     <div class="uk-dropdown uk-dropdown-close">
                                         <ul class="uk-nav uk-nav-dropdown">
                                             <li class="uk-nav-header">@lang('Copy content from:')</li>
-                                            <li show="{parent.lang}"><a onclick="{parent.copyLocalizedValue}" lang="" field="{field.name}">@lang('Default')</a></li>
+                                            <li show="{parent.lang}"><a onclick="{parent.copyLocalizedValue}" lang="" field="{field.name}">{App.$data.languageDefaultLabel}</a></li>
                                             <li show="{parent.lang != language.code}" each="{language,idx in languages}" value="{language.code}"><a onclick="{parent.parent.copyLocalizedValue}" lang="{language.code}" field="{field.name}">{language.label}</a></li>
                                         </ul>
                                     </div>


### PR DESCRIPTION
The default language name in config is not used as label for "Copy content from"