### PR TITLE
Collection live preview i18n lang fix

### DIFF
--- a/modules/Collections/assets/collection-entrypreview.tag
+++ b/modules/Collections/assets/collection-entrypreview.tag
@@ -133,7 +133,7 @@
                             </span>
 
                             <select bind="lang">
-                                <option value="">{ App.i18n.get('Default') }</option>
+                                <option value="">{ App.$data.languageDefaultLabel }</option>
                                 <option each="{language,idx in languages}" value="{language.code}">{language.label}</option>
                             </select>
                         </div>
@@ -201,7 +201,7 @@
 
         this.mode = 'desktop';
         this.group = '';
-        this.lang = '';
+        this.lang = opts.lang || '';
         this.$idle = false;
 
         this.settings = App.$.extend({
@@ -293,6 +293,7 @@
             clearInterval(this.$idle);
             document.body.style.overflow = '';
             this.parent.preview = false;
+            this.parent.lang = this.lang;
             this.parent.update();
         }
 

--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -185,7 +185,7 @@
 
     </div>
 
-    <collection-entrypreview collection="{collection}" entry="{entry}" groups="{ groups }" fields="{ fields }" fieldsidx="{ fieldsidx }" excludeFields="{ excludeFields }" languages="{ languages }" settings="{ collection.contentpreview }" if="{ preview }"></collection-entrypreview>
+    <collection-entrypreview collection="{collection}" entry="{entry}" groups="{ groups }" fields="{ fields }" fieldsidx="{ fieldsidx }" excludeFields="{ excludeFields }" languages="{ languages }" lang="{ lang }" settings="{ collection.contentpreview }" if="{ preview }"></collection-entrypreview>
     <cp-inspectobject ref="inspect"></cp-inspectobject>
 
     <script type="view/script">


### PR DESCRIPTION
Collection live preview should:
* keep the selected language from the collection entry page
* display the default language label instead of the i18n

This PR fixes both issues