### PR TITLE
Added $file to cockpit.asset.upload trigger

### DIFF
--- a/modules/Cockpit/module/assets.php
+++ b/modules/Cockpit/module/assets.php
@@ -88,7 +88,7 @@ $this->module('cockpit')->extend([
             $opts  = ['mimetype' => $asset['mime']];
             $_meta = isset($meta[$idx]) && is_array($meta[$idx]) ? $meta[$idx] : $meta;
 
-            $this->app->trigger('cockpit.asset.upload', [&$asset, &$_meta, &$opts]);
+            $this->app->trigger('cockpit.asset.upload', [&$asset, &$_meta, &$opts, &$file]);
 
             if (!$asset) {
                 continue;


### PR DESCRIPTION
I am creating an addon to modify assets before they are uploaded and I need to get the path to the tmp file. Using the data available in the cockpit.asset.upload event, I cannot find the tmp files without passing the $file variable.