### PR TITLE
Added option to set collection entries sorting

### DIFF
--- a/modules/Cockpit/assets/components/field-select.tag
+++ b/modules/Cockpit/assets/components/field-select.tag
@@ -2,7 +2,7 @@
 
     <select ref="input" class="uk-width-1-1 {opts.cls}" bind="{ opts.bind }">
         <option value=""></option>
-        <option each="{ option,idx in options }" value="{ option.value }" selected="{ parent.root.$value === option.value }">{ option.label }</option>
+        <option each="{ option,idx in options }" value="{ option.value }" selected="{ parent.root.$value == option.value }">{ option.label }</option>
     </select>
 
     <script>

--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -76,6 +76,8 @@ class Admin extends \Cockpit\AuthController {
             'fields'=>[],
             'acl' => new \ArrayObject,
             'sortable' => false,
+            'sort_column_name' => '_created',
+            'sort_direction' => -1,
             'in_menu' => false
         ];
 
@@ -170,6 +172,8 @@ class Admin extends \Cockpit\AuthController {
 
         $collection = array_merge([
             'sortable' => false,
+            'sort_column_name' => '_created',
+            'sort_direction' => -1,
             'color' => '',
             'icon' => '',
             'description' => ''
@@ -219,6 +223,8 @@ class Admin extends \Cockpit\AuthController {
 
         $collection = array_merge([
             'sortable' => false,
+            'sort_column_name' => '_created',
+            'sort_direction' => -1,
             'color' => '',
             'icon' => '',
             'description' => ''

--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -76,8 +76,10 @@ class Admin extends \Cockpit\AuthController {
             'fields'=>[],
             'acl' => new \ArrayObject,
             'sortable' => false,
-            'sort_column_name' => '_created',
-            'sort_direction' => -1,
+            'sort' => [
+                'column' => '_created',
+                'dir' => -1,
+            ],
             'in_menu' => false
         ];
 
@@ -172,8 +174,10 @@ class Admin extends \Cockpit\AuthController {
 
         $collection = array_merge([
             'sortable' => false,
-            'sort_column_name' => '_created',
-            'sort_direction' => -1,
+            'sort' => [
+                'column' => '_created',
+                'dir' => -1,
+            ],
             'color' => '',
             'icon' => '',
             'description' => ''
@@ -223,8 +227,10 @@ class Admin extends \Cockpit\AuthController {
 
         $collection = array_merge([
             'sortable' => false,
-            'sort_column_name' => '_created',
-            'sort_direction' => -1,
+            'sort' => [
+                'column' => '_created',
+                'dir' => -1,
+            ],
             'color' => '',
             'icon' => '',
             'description' => ''

--- a/modules/Collections/views/collection.php
+++ b/modules/Collections/views/collection.php
@@ -69,12 +69,12 @@
 
                     <div class="uk-margin">
                         <label class="uk-text-small">@lang('Sort by')</label>
-                        <field-select bind="collection.sort_column_name" options="{ getFieldsSortColumnNameOptions() }"></field-select>
+                        <field-select bind="collection.sort.column" options="{ getFieldsSortColumnNameOptions() }"></field-select>
                     </div>
 
                     <div class="uk-margin">
                         <label class="uk-text-small">@lang('Sort direction')</label>
-                        <field-select bind="collection.sort_direction" options="{ fieldsSortDirectionOptions }"></field-select>
+                        <field-select bind="collection.sort.dir" options="{ fieldsSortDirectionOptions }"></field-select>
                     </div>
 
                     @trigger('collections.settings.aside')
@@ -291,9 +291,17 @@
                 this.refs.name.disabled = true;
             }
 
+            // Add default sort properties for collection created previously without sort feature
+            if (!this.collection.sort) {
+                this.collection.sort = {
+                    column: '_created',
+                    dir: -1
+                }
+            }
+
             // Cast to integer
-            if (this.collection.sort_direction) {
-                this.collection.sort_direction = parseInt(this.collection.sort_direction, 10)
+            if (typeof this.collection.sort.dir === 'string') {
+                this.collection.sort.dir = parseInt(this.collection.sort.dir, 10)
             }
         });
 

--- a/modules/Collections/views/collection.php
+++ b/modules/Collections/views/collection.php
@@ -290,6 +290,11 @@
             if (this.collection._id) {
                 this.refs.name.disabled = true;
             }
+
+            // Cast to integer
+            if (this.collection.sort_direction) {
+                this.collection.sort_direction = parseInt(this.collection.sort_direction, 10)
+            }
         });
 
         this.on('mount', function(){

--- a/modules/Collections/views/collection.php
+++ b/modules/Collections/views/collection.php
@@ -69,12 +69,12 @@
 
                     <div class="uk-margin">
                         <label class="uk-text-small">@lang('Sort by')</label>
-                        <field-select bind="collection.sort_by" options="{ getFieldsSortByOptions() }"></field-select>
+                        <field-select bind="collection.sort_column_name" options="{ getFieldsSortColumnNameOptions() }"></field-select>
                     </div>
 
                     <div class="uk-margin">
                         <label class="uk-text-small">@lang('Sort direction')</label>
-                        <field-select bind="collection.sort_dir" options="{ fieldsSortDirOptions }"></field-select>
+                        <field-select bind="collection.sort_direction" options="{ fieldsSortDirectionOptions }"></field-select>
                     </div>
 
                     @trigger('collections.settings.aside')
@@ -274,9 +274,14 @@
             this.collection.acl = {};
         }
 
-        this.fieldsSortDirOptions = [
-            {value: -1, label: App.i18n.get('Ascending')},
-            {value:  1, label: App.i18n.get('Descending')}
+        this.fieldsSortDirectionOptions = [
+            { value: -1, label: App.i18n.get('Ascending') },
+            { value:  1, label: App.i18n.get('Descending') }
+        ]
+
+        var timestampSortOptions = [
+            { value: '_created', label: App.i18n.get('Created') },
+            { value: '_modified', label: App.i18n.get('Modified') }
         ]
 
         this.on('update', function(){
@@ -320,11 +325,13 @@
         }
 
         // Convert fields to format required by select
-        getFieldsSortByOptions() {
-            return this.collection.fields.map(field => ({
-                value: field.name,
-                label: field.label || field.name
-            }))
+        getFieldsSortColumnNameOptions() {
+            return this.collection.fields
+                .map(field => ({
+                    value: field.name,
+                    label: field.label || field.name
+                }))
+                .concat(timestampSortOptions)
         }
 
         submit(e) {

--- a/modules/Collections/views/collection.php
+++ b/modules/Collections/views/collection.php
@@ -67,6 +67,16 @@
                         <field-boolean bind="collection.sortable" title="@lang('Sortable entries')" label="@lang('Custom sortable entries')"></field-boolean>
                     </div>
 
+                    <div class="uk-margin">
+                        <label class="uk-text-small">@lang('Sort by')</label>
+                        <field-select bind="collection.sort_by" options="{ getFieldsSortByOptions() }"></field-select>
+                    </div>
+
+                    <div class="uk-margin">
+                        <label class="uk-text-small">@lang('Sort direction')</label>
+                        <field-select bind="collection.sort_dir" options="{ fieldsSortDirOptions }"></field-select>
+                    </div>
+
                     @trigger('collections.settings.aside')
 
                 </div>
@@ -264,6 +274,11 @@
             this.collection.acl = {};
         }
 
+        this.fieldsSortDirOptions = [
+            {value: -1, label: App.i18n.get('Ascending')},
+            {value:  1, label: App.i18n.get('Descending')}
+        ]
+
         this.on('update', function(){
 
             // lock name if saved
@@ -302,6 +317,14 @@
 
         selectIcon(e) {
             this.collection.icon = e.target.getAttribute('icon');
+        }
+
+        // Convert fields to format required by select
+        getFieldsSortByOptions() {
+            return this.collection.fields.map(field => ({
+                value: field.name,
+                label: field.label || field.name
+            }))
         }
 
         submit(e) {

--- a/modules/Collections/views/partials/entries.php
+++ b/modules/Collections/views/partials/entries.php
@@ -353,7 +353,7 @@
         this.fields.push(this.fieldsidx['_created']);
         this.fields.push(this.fieldsidx['_modified']);
 
-        this.sort     = {'_created': -1};
+        this.sort     = {[this.collection.sort_by || '_created'] : this.collection.sort_dir || -1}
         this.selected = [];
         this.listmode = App.session.get('collections.entries.'+this.collection.name+'.listmode', 'list');
 

--- a/modules/Collections/views/partials/entries.php
+++ b/modules/Collections/views/partials/entries.php
@@ -354,7 +354,7 @@
         this.fields.push(this.fieldsidx['_modified']);
 
         this.sort = {}
-        this.sort[this.collection.sort_column_name] = this.collection.sort_direction
+        this.sort[this.collection.sort.column] = this.collection.sort.dir
         this.selected = [];
         this.listmode = App.session.get('collections.entries.'+this.collection.name+'.listmode', 'list');
 

--- a/modules/Collections/views/partials/entries.php
+++ b/modules/Collections/views/partials/entries.php
@@ -353,7 +353,8 @@
         this.fields.push(this.fieldsidx['_created']);
         this.fields.push(this.fieldsidx['_modified']);
 
-        this.sort     = {[this.collection.sort_by || '_created'] : this.collection.sort_dir || -1}
+        this.sort = {}
+        this.sort[this.collection.sort_column_name] = this.collection.sort_direction
         this.selected = [];
         this.listmode = App.session.get('collections.entries.'+this.collection.name+'.listmode', 'list');
 


### PR DESCRIPTION
This adds an option to set collection entries sorting in the collection screen.
You may choose from one of the fields and direction.

![image](https://user-images.githubusercontent.com/612953/74424455-47604e00-4e52-11ea-8257-826563e31db3.png)
