### PR TITLE
Fix URL generation when site_url and root paths are not the same

### DIFF
--- a/lib/Lime/App.php
+++ b/lib/Lime/App.php
@@ -420,7 +420,7 @@ class App implements \ArrayAccess {
             $url = \implode('/', \array_map('rawurlencode', explode('/', $url)));
 
             if ($full) {
-                $url = \rtrim($this->registry['site_url'], '/').$url;
+                $url = str_replace($this->path('site:'), '/', \rtrim($this->registry['site_url'], '/').$url);
             }
         }
 

--- a/lib/LimeExtra/App.php
+++ b/lib/LimeExtra/App.php
@@ -192,7 +192,7 @@ class App extends \Lime\App {
                 $this->helper('fs')->write($path, implode("\n", $contents));
             }
 
-            $url = $this->pathToUrl($path);
+            $url = $this->pathToUrl($path, ($this->path('site:') != $this->path('#root:')));
             $list[] = '<script src="'.($url.($version ? "?ver={$version}":'')).'" type="text/javascript"></script>';
         }
 

--- a/modules/Cockpit/Controller/Media.php
+++ b/modules/Cockpit/Controller/Media.php
@@ -72,7 +72,7 @@ class Media extends \Cockpit\AuthController {
                         'name' => $filename,
                         'path' => trim($path.'/'.$file->getFilename(), '/'),
                         'rel_site_path' => trim(str_replace($sitefolder, '', $file->getPathname()), '/'),
-                        'url'  => $this->app->pathToUrl($file->getPathname()),
+                        'url'  => $this->app->pathToUrl($file->getPathname(), ($sitefolder != $this->path('#root:'))),
                         'size' => $isDir ? '' : $this->app->helper('utils')->formatSize($file->getSize()),
                         'filesize' => $isDir ? '' : $file->getSize(),
                         'ext'  => $isDir ? '' : strtolower($file->getExtension()),


### PR DESCRIPTION
In my setup, I use the defines.php file to define COCKPIT_SITE_DIR , COCKPIT_STORAGE_FOLDER and COCKPIT_PUBLIC_STORAGE_FOLDER separately for each site, based on EnvVars set in apache config.
When doing that, URLs generated for AssetManager generated javascript, and any Image in Finder were messed up, so none of them could be previewed or opened in a separate tab.
This commit aims to fix that, with having the original code and setup in mind.

I have tested this with the original setup (following normal cockpit install instructions, with no changes and no defines.php), and with my new setup.