### PR TITLE
Add Cockpit + PHP7.2 + Nginx docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ make also sure that <code>$_SERVER['DOCUMENT_ROOT']</code> exists and is set cor
 3. Go to __/cockpit/install__ via Browser
 4. You're ready to use Cockpit :-)
 
+or
+
+1. Run the command `docker run -p 8080:80 gabskoro/cockpit-nginx`
+2. Open `http://localhost:8080/install`
+
 
 ### Build (Only if you modify JS components)
 


### PR DESCRIPTION
I created a docker image that: 
* Used PHP 7.2 + required modules (sqlite3, gd, mbstring, curl)
* Uses Nginx
* Downloads the application zip file  from this repository

If you think this is nice to have, feel free to merge it or let me know if we should maybe move the text somewhere else rather then on the Readme page