### PR TITLE
handles listing and upload based on field configuration

### DIFF
--- a/modules/Cockpit/assets/cockpit.js
+++ b/modules/Cockpit/assets/cockpit.js
@@ -100,13 +100,14 @@
             select: function(callback, options){
 
                 options  = App.$.extend({
+                    pattern: "*.*",
                     selected : []
                 }, options);
 
                 var selected = [], dialog = UIkit.modal.dialog([
                     '<div>',
                         '<div class="uk-modal-header uk-text-large">'+App.i18n.get('Select asset')+'</div>',
-                        '<cp-assets path="'+(options.path || '')+'" typefilter="'+(options.typefilter || '')+'" modal="true"></cp-assets>',
+                        '<cp-assets pattern="' + (options.pattern || '*.*') + '" path="'+(options.path || '')+'" typefilter="'+(options.typefilter || '')+'" modal="true"></cp-assets>',
                         '<div class="uk-modal-footer uk-text-right">',
                             '<button class="uk-button uk-button-primary uk-margin-right uk-button-large uk-hidden js-select-button">'+App.i18n.get('Select')+': <span></span> item(s)</button>',
                             '<a class="uk-button uk-button-large uk-button-link uk-modal-close">'+App.i18n.get('Close')+'</a>',

--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -125,10 +125,11 @@ riot.tag2('cp-assets', '<div ref="list" show="{mode==\'list\'}"> <div ref="uploa
         this.page     = 1;
         this.pages    = 1;
         this.limit    = opts.limit || 15;
+        this.pattern    = opts.pattern || '*.*'
 
         this.on('mount', function() {
 
-            this.listAssets(1);
+            this.updateFilter();
 
             App.assets.require(['/assets/lib/uikit/js/components/upload.js'], function() {
 
@@ -136,6 +137,7 @@ riot.tag2('cp-assets', '<div ref="list" show="{mode==\'list\'}"> <div ref="uploa
 
                     action: App.route('/assetsmanager/upload'),
                     type: 'json',
+                    allow: $this.pattern,
                     before: function(options) {
                         options.params.folder = $this.folder
                     },
@@ -176,7 +178,8 @@ riot.tag2('cp-assets', '<div ref="list" show="{mode==\'list\'}"> <div ref="uploa
                             App.ui.notify("Something went wrong.", "danger");
                         }
 
-                    }
+                    },
+
                 },
 
                 uploadselect = UIkit.uploadSelect(App.$('.js-upload-select', $this.root)[0], uploadSettings),
@@ -232,8 +235,12 @@ riot.tag2('cp-assets', '<div ref="list" show="{mode==\'list\'}"> <div ref="uploa
 
             this.filter = null;
 
-            if (this.refs.filtertitle.value || this.refs.filtertype.value) {
+            if (this.refs.filtertitle.value || this.refs.filtertype.value || this.pattern !== '*.*') {
                 this.filter = {};
+            }
+
+            if (this.pattern !== '*.*') {
+                this.filter.path = {'$regex': '^.*\.(' + this.pattern.replace(/\*./g, '') + ')$', '$options': 'i'};
             }
 
             if (this.refs.filtertitle.value) {
@@ -1856,6 +1863,7 @@ riot.tag2('field-asset', '<div ref="uploadprogress" class="uk-margin uk-hidden">
         }.bind(this);
 
         this.on('mount', function() {
+            $this.pattern = opts.pattern || '*.*';
 
             App.assets.require(['/assets/lib/uikit/js/components/upload.js'], function() {
 
@@ -1864,6 +1872,7 @@ riot.tag2('field-asset', '<div ref="uploadprogress" class="uk-margin uk-hidden">
                     action: App.route('/assetsmanager/upload'),
                     type: 'json',
                     filelimit: 1,
+                    allow: (this.opts.upload && this.opts.upload.allow) || '*.*',
                     before: function(options) {
 
                     },
@@ -1904,7 +1913,7 @@ riot.tag2('field-asset', '<div ref="uploadprogress" class="uk-margin uk-hidden">
                 if (Array.isArray(assets)) {
                     $this.$setValue(assets[0]);
                 }
-            });
+            }, { pattern: $this.pattern });
         }.bind(this)
 
         this.reset = function() {

--- a/modules/Cockpit/assets/components/cp-assets.tag
+++ b/modules/Cockpit/assets/components/cp-assets.tag
@@ -272,10 +272,11 @@
         this.page     = 1;
         this.pages    = 1;
         this.limit    = opts.limit || 15;
+        this.pattern    = opts.pattern || '*.*'
 
         this.on('mount', function() {
 
-            this.listAssets(1);
+            this.updateFilter();
 
             // handle uploads
             App.assets.require(['/assets/lib/uikit/js/components/upload.js'], function() {
@@ -284,6 +285,7 @@
 
                     action: App.route('/assetsmanager/upload'),
                     type: 'json',
+                    allow: $this.pattern,
                     before: function(options) {
                         options.params.folder = $this.folder
                     },
@@ -324,7 +326,8 @@
                             App.ui.notify("Something went wrong.", "danger");
                         }
 
-                    }
+                    },
+                    
                 },
 
                 uploadselect = UIkit.uploadSelect(App.$('.js-upload-select', $this.root)[0], uploadSettings),
@@ -380,8 +383,12 @@
 
             this.filter = null;
 
-            if (this.refs.filtertitle.value || this.refs.filtertype.value) {
+            if (this.refs.filtertitle.value || this.refs.filtertype.value || this.pattern !== '*.*') {
                 this.filter = {};
+            }
+
+            if (this.pattern !== '*.*') {
+                this.filter.path = {'$regex': '^.*\.(' + this.pattern.replace(/\*./g, '') + ')$', '$options': 'i'};
             }
 
             if (this.refs.filtertitle.value) {

--- a/modules/Cockpit/assets/components/field-asset.tag
+++ b/modules/Cockpit/assets/components/field-asset.tag
@@ -79,6 +79,7 @@
         }.bind(this);
 
         this.on('mount', function() {
+            $this.pattern = opts.pattern || '*.*';
 
             // handle uploads
             App.assets.require(['/assets/lib/uikit/js/components/upload.js'], function() {
@@ -88,6 +89,7 @@
                     action: App.route('/assetsmanager/upload'),
                     type: 'json',
                     filelimit: 1,
+                    allow: (this.opts.upload && this.opts.upload.allow) || '*.*',
                     before: function(options) {
 
                     },
@@ -128,7 +130,7 @@
                 if (Array.isArray(assets)) {
                     $this.$setValue(assets[0]);
                 }
-            });
+            }, { pattern: $this.pattern });
         }
 
         reset() {


### PR DESCRIPTION
This should not break existing functionality.

Having an asset field configured like:

```
{
  "pattern": "*.png|*.jpg|*.pdf"
}
```

When opening the assets dialog it will only list files matching the pattern.
When trying to upload an asset it will fail with an alert (UIKit uploadSelect) if file extension doesn't match the pattern.