### PR TITLE
Merging parentComponent options growing exponentially

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -2783,7 +2783,7 @@ riot.tag2('field-layout', '<div class="uk-sortable layout-components {!items.len
         }
 
         if (opts.parentComponent && opts.parentComponent.options) {
-            opts = App.$.extend(true, opts.parentComponent.options, opts);
+            opts = App.$.extend(true, {}, opts.parentComponent.options, opts);
         }
 
         this.on('mount', function() {

--- a/modules/Cockpit/assets/components/field-layout.tag
+++ b/modules/Cockpit/assets/components/field-layout.tag
@@ -250,7 +250,7 @@
         }
 
         if (opts.parentComponent && opts.parentComponent.options) {
-            opts = App.$.extend(true, opts.parentComponent.options, opts);
+            opts = App.$.extend(true, {}, opts.parentComponent.options, opts);
         }
 
         


### PR DESCRIPTION
I don't really know why, but merging parentComponent options grows exponentially making the entry page very slow to load and possibly out of memory when you have many layout components.
By debugging and testing copying data in different ways, I found out that cloning the data before extending helped.

This fixes slow entry pages with many layout components. Not sure how many has had problems with it.