### PR TITLE
Add Runme button to demonstrate the latest version of application

### DIFF
--- a/.runme/Dockerfile
+++ b/.runme/Dockerfile
@@ -1,0 +1,25 @@
+FROM php:7-apache
+
+RUN apt-get update \
+    && apt-get install -y \
+		wget zip unzip \
+        libzip-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        sqlite3 libsqlite3-dev \
+        libssl-dev \
+    && pecl install mongodb \
+    && pecl install redis \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) iconv gd pdo zip opcache pdo_sqlite \
+    && a2enmod rewrite expires
+RUN echo "extension=mongodb.so" > /usr/local/etc/php/conf.d/mongodb.ini && \
+    echo "extension=redis.so" > /usr/local/etc/php/conf.d/redis.ini
+
+WORKDIR /var/www/html
+COPY . .
+
+RUN chown -R www-data:www-data /var/www/html
+
+CMD ["apache2-foreground"]

--- a/.runme/Dockerfile
+++ b/.runme/Dockerfile
@@ -22,4 +22,4 @@ COPY . .
 
 RUN chown -R www-data:www-data /var/www/html
 
-CMD ["apache2-foreground"]
+CMD ["/bin/bash", "-c", "set -m; apache2-foreground & for i in {1..10}; do curl http://localhost/install/ -v && s=$$? && break || s=$$?; sleep 1; done; fg %1"]

--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,0 +1,11 @@
+version: 1.0
+publish: app
+services:
+  app:
+    command: some
+    build:
+      type: dockerfile
+      config: ./Dockerfile
+    ports:
+      - container: 8080
+        public: 80

--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -2,10 +2,9 @@ version: 1.0
 publish: app
 services:
   app:
-    command: some
     build:
       type: dockerfile
-      config: ./Dockerfile
+      config: ./.runme/Dockerfile
     ports:
-      - container: 8080
+      - container: 80
         public: 80

--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -5,6 +5,19 @@ services:
     build:
       type: dockerfile
       config: ./.runme/Dockerfile
+    environment:
+      COCKPIT_SESSION_NAME: cockpit
+      COCKPIT_SALT: S0meS@lt
+      COCKPIT_DATABASE_SERVER: 'mongodb://root:password@mongo:27017'
+      COCKPIT_DATABASE_NAME: cockpit_master
     ports:
       - container: 80
         public: 80
+
+  mongo:
+    image: bitnami/mongodb:4.0
+    environment:
+      MONGODB_REPLICA_SET_MODE: primary
+      MONGODB_REPLICA_SET_NAME: rs0
+      MONGODB_ROOT_PASSWORD: password
+      MONGODB_REPLICA_SET_KEY: replicasetkey123

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ You need docker installed on your system: https://www.docker.com.
 1. Run `npm run docker-init` to build the initial image.
 2. Run `npm run docker` to start an Apache environment suited for Cockpit on port 8080 (this folder mapped to /var/www/html).
 
-### Demo 
-[![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=094f9c4e-a928-4e01-9cd9-6dd9614b7f83)
+### Demo
+[![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=c434919d-937d-4b93-9692-4919bc1ea03a)
 
 ## 💐 Partners
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ You need docker installed on your system: https://www.docker.com.
 1. Run `npm run docker-init` to build the initial image.
 2. Run `npm run docker` to start an Apache environment suited for Cockpit on port 8080 (this folder mapped to /var/www/html).
 
+### Demo 
+[![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=094f9c4e-a928-4e01-9cd9-6dd9614b7f83)
 
 ## 💐 Partners
 


### PR DESCRIPTION
This PR adds Runme button-label [![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=a49614df-d131-41d8-a34f-9479994030eb) (clickable) to run the project from latest commit with one click.

**How it works:**
1. Runme clones the repository and builds a docker image for latest commit or use already built docker image;
2. deploys the docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.

You can find detailed information how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

**Why do you need this?**
- Runme is perfect solution to demonstrate current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme can be used as a tool for preparation docker images with a developer's version of code

**Screenshots**
build
![build](https://user-images.githubusercontent.com/8326634/83135649-ccfcc680-a0ee-11ea-8f67-828112837c5d.png)
result
![result](https://user-images.githubusercontent.com/8326634/83135572-adfe3480-a0ee-11ea-808f-b32c6966015f.png)
