### PR TITLE
Configurable templates

### DIFF
--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -105,7 +105,12 @@ class Admin extends \Cockpit\AuthController {
         // get field templates
         $templates = [];
 
-        foreach ($this->app->helper('fs')->ls('*.php', 'collections:fields-templates') as $file) {
+        $templatesPath = 'collections:fields-templates';
+        if ($customTemplatesPath = $this->path('#config:collections/templates')) {
+            $templatesPath = $customTemplatesPath;
+        }
+
+        foreach ($this->app->helper('fs')->ls('*.php', $templatesPath) as $file) {
             $templates[] = include($file->getRealPath());
         }
 

--- a/modules/Singletons/Controller/Admin.php
+++ b/modules/Singletons/Controller/Admin.php
@@ -69,6 +69,19 @@ class Admin extends \Cockpit\AuthController {
             $this->app->helper('admin')->lockResourceId($singleton['_id']);
         }
 
+        // get field templates
+        $templates = [];
+
+        if ($templatesPath = $this->path('#config:singletons/templates')) {
+            foreach ($this->app->helper('fs')->ls('*.php', $templatesPath) as $file) {
+                $templates[] = include($file->getRealPath());
+            }
+        }
+
+        foreach ($this->app->module('singletons')->singletons() as $sin) {
+            $templates[] = $sin;
+        }
+
         // acl groups
         $aclgroups = [];
 
@@ -77,7 +90,7 @@ class Admin extends \Cockpit\AuthController {
             if (!$superAdmin) $aclgroups[] = $group;
         }
 
-        return $this->render('singletons:views/singleton.php', compact('singleton', 'aclgroups'));
+        return $this->render('singletons:views/singleton.php', compact('singleton', 'aclgroups', 'templates'));
     }
 
     public function form($name = null) {

--- a/modules/Singletons/views/singleton.php
+++ b/modules/Singletons/views/singleton.php
@@ -82,7 +82,7 @@
 
                     <div class="uk-margin-large-top" show="{ view==='fields' }">
 
-                        <cp-fieldsmanager bind="singleton.fields"></cp-fieldsmanager>
+                        <cp-fieldsmanager bind="singleton.fields" listoption="true" templates="{ templates }"></cp-fieldsmanager>
 
                     </div>
 
@@ -162,7 +162,8 @@
         this.view = 'fields';
 
         this.singleton = {{ json_encode($singleton) }};
-        this.aclgroups  = {{ json_encode($aclgroups) }};
+        this.templates = {{ json_encode($templates) }};
+        this.aclgroups = {{ json_encode($aclgroups) }};
 
         if (!this.singleton.acl) {
             this.singleton.acl = {};


### PR DESCRIPTION
Singletons now have the same template functionality like collections, so existing singletons are proposed when hovering over "Add field" while creating a new singleton.

Collections and singletons can have custom templates in `#config:collections/templates/*.php` and `#config:singletons/templates/*.php`.

For collections: If the custom config templates folder exists, the folder `collections:fields-templates` will be ignored.