### PR TITLE
create bootstrap.php when creating folder via finder in addons dir

### DIFF
--- a/modules/Cockpit/Controller/Media.php
+++ b/modules/Cockpit/Controller/Media.php
@@ -193,7 +193,14 @@ class Media extends \Cockpit\AuthController {
         $ret  = false;
 
         if ($name && $path) {
-            $ret = mkdir($this->root.'/'.trim($path, '/').'/'.$name);
+            $parentFolder = $this->root.'/'.trim($path, '/').'/';
+            $ret = mkdir($parentFolder.$name);
+
+            // prevent fatal error when creating folders without bootstrap.php in addons/modules dirs
+            // see this discussion, why it is necessary; https://github.com/agentejo/cockpit/pull/1019
+            if ($ret && in_array($parentFolder,[$this->path('#addons:'), $this->path('#modules:')])) {
+                @file_put_contents($parentFolder.$name.'/bootstrap.php', "<?php\r\n");
+            }
         }
 
         return json_encode(['success' => $ret]);


### PR DESCRIPTION
This issue came up so often and it is still a way to break the whole cockpit instance with a simple folder creation via ui.

Now the media api controller takes care of this and creates an empty `bootstrap.php` file after creating an empty folder inside the addons or the modules folder.

fixes #1215, fixes #1314