### PR TITLE
lang query param on collection entry page

### DIFF
--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -214,6 +214,10 @@
 
         if (this.languages.length) {
             this.lang = App.session.get('collections.entry.'+this.collection._id+'.lang', '');
+            if (typeof window.URLSearchParams === 'function') {
+                var langParam = new URLSearchParams(document.location.search.substring(1)).get("lang");
+                if (langParam) this.lang = langParam;
+            }
         }
 
         // fill with default values


### PR DESCRIPTION
Our frontend implementation prints links to edit collection entries in cockpit and since we use localization, we need to link to edit the entry in the correct language.  When the lang is set in the entry, it first reads from the sessions storage and then looks for a query param called "lang". I didn't see any easy way to implement this in a addon, so I had to make the change in core.