### PR TITLE
Override restrict and exclude in layout component from parent component

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -2886,6 +2886,11 @@ riot.tag2('field-layout', '<div class="uk-sortable layout-components {!items.len
 
         if (opts.parentComponent && opts.parentComponent.options) {
             opts = App.$.extend(true, {}, opts.parentComponent.options, opts);
+            for (var field of ["restrict", "exclude"]) {
+                if (opts.parentComponent.options[field] !== undefined) {
+                    opts[field] = opts.parentComponent.options[field];
+                }
+            }
         }
 
         this.on('mount', function() {
@@ -3015,7 +3020,7 @@ riot.tag2('field-layout', '<div class="uk-sortable layout-components {!items.len
                 }
                 n = n.parent;
             }
-        }
+        };
 
         this.isComponentAvailable = function(name) {
 

--- a/modules/Cockpit/assets/components/field-layout.tag
+++ b/modules/Cockpit/assets/components/field-layout.tag
@@ -251,6 +251,11 @@
 
         if (opts.parentComponent && opts.parentComponent.options) {
             opts = App.$.extend(true, {}, opts.parentComponent.options, opts);
+            for (var field of ["restrict", "exclude"]) {
+                if (opts.parentComponent.options[field] !== undefined) {
+                    opts[field] = opts.parentComponent.options[field];
+                }
+            }
         }
 
         
@@ -381,7 +386,7 @@
                 }
                 n = n.parent;
             }
-        }
+        };
 
         isComponentAvailable(name) {
 


### PR DESCRIPTION
Field-layout restrict and exclude are inherited to child layout items. This prohibits setting retrictions on a component with children to restrict its children.

Example, create a layout field with the following options json:
```
{
  "restrict": [
    "Container 1",
    "Container 2"
  ],
  "components": {
    "Container 1": {
      "children": true,
      "options": {
        "restrict": [
          "Child"
        ]
      }
    },
    "Container 2": {
      "children": true,
      "options": {
        "restrict": [
          "Child"
        ]
      }
    },
    "Child": []
  }
}
```
The idea is that the root can contain Container 1 and 2 and they can only contain Children. This does not work with the current implementation.

This PR implements that restrict and exclude gets overriden by the parentComponent ditto.

Please label with hacktoberfest-accepted (read more: https://hacktoberfest.digitalocean.com/hacktoberfest-update) if you accept it :)