### PR TITLE
Added triggers to collection admin find filters

### DIFF
--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -535,6 +535,8 @@ class Admin extends \Cockpit\AuthController {
         $criterias    = [];
         $_filter      = null;
 
+        $this->app->trigger("collections.admin._filterMongo.before", [&$filter, &$allowedtypes, &$criterias]);
+
         foreach ($collection['fields'] as $field) {
 
             $name = $field['name'];
@@ -570,6 +572,7 @@ class Admin extends \Cockpit\AuthController {
                 $criterias[] = $criteria;
             }
 
+            $this->app->trigger("collections.admin._filterMongo.field", [$name, $field, $filter, &$criterias]);
         }
 
         if (count($criterias)) {

--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -518,7 +518,7 @@ class Admin extends \Cockpit\AuthController {
     protected function _filter($filter, $collection, $lang = null) {
 
         if ($this->app->storage->type == 'mongolite') {
-            return $this->_filterLight($filter, $collection, $lang);
+            return $this->_filterMongo($filter, $collection, $lang, true);
         }
 
         if ($this->app->storage->type == 'mongodb') {
@@ -529,7 +529,7 @@ class Admin extends \Cockpit\AuthController {
 
     }
 
-    protected function _filterLight($filter, $collection, $lang) {
+    protected function _filterMongo($filter, $collection, $lang, $isMongoLite = false) {
 
         $allowedtypes = ['text','longtext','boolean','select','html','wysiwyg','markdown','code'];
         $criterias    = [];
@@ -546,59 +546,27 @@ class Admin extends \Cockpit\AuthController {
             if ($field['type'] != 'boolean' && in_array($field['type'], $allowedtypes)) {
                 $criteria = [];
                 $criteria[$name] = ['$regex' => $filter];
+                if (!$isMongoLite) {
+                  $criteria[$name]['$options'] = 'i';
+                }
                 $criterias[] = $criteria;
             }
 
             if ($field['type']=='collectionlink') {
                 $criteria = [];
                 $criteria[$name.'.display'] = ['$regex' => $filter];
+                if (!$isMongoLite) {
+                  $criteria[$name]['$options'] = 'i';
+                }
                 $criterias[] = $criteria;
             }
 
             if ($field['type']=='location') {
                 $criteria = [];
                 $criteria[$name.'.address'] = ['$regex' => $filter];
-                $criterias[] = $criteria;
-            }
-
-        }
-
-        if (count($criterias)) {
-            $_filter = ['$or' => $criterias];
-        }
-
-        return $_filter;
-    }
-
-    protected function _filterMongo($filter, $collection, $lang) {
-
-        $allowedtypes = ['text','longtext','boolean','select','html','wysiwyg','markdown','code'];
-        $criterias    = [];
-        $_filter      = null;
-
-        foreach ($collection['fields'] as $field) {
-
-            $name = $field['name'];
-
-            if ($lang && $field['localize']) {
-                $name = "{$name}_{$lang}";
-            }
-
-            if ($field['type'] != 'boolean' && in_array($field['type'], $allowedtypes)) {
-                $criteria = [];
-                $criteria[$name] = ['$regex' => $filter, '$options' => 'i'];
-                $criterias[] = $criteria;
-            }
-
-            if ($field['type']=='collectionlink') {
-                $criteria = [];
-                $criteria[$name.'.display'] = ['$regex' => $filter, '$options' => 'i'];
-                $criterias[] = $criteria;
-            }
-
-            if ($field['type']=='location') {
-                $criteria = [];
-                $criteria[$name.'.address'] = ['$regex' => $filter, '$options' => 'i'];
+                if (!$isMongoLite) {
+                  $criteria[$name]['$options'] = 'i';
+                }
                 $criterias[] = $criteria;
             }
 


### PR DESCRIPTION
To be able to handle default search functionality in custom fieldtypes we needed triggers where cockpit creates the default search filters.

Also, the mongo and mongolite internal filter functions were similar down to adding the case sensitive options, so I merged them and added a boolean flag to select if it should be for mongolite.