### PR TITLE
Bugfix updated admin filters

### DIFF
--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -551,7 +551,7 @@ class Admin extends \Cockpit\AuthController {
                 $criteria[$name.'.display'] = ['$regex' => $filter];
 
                 if (!$isMongoLite) {
-                  $criteria[$name]['$options'] = 'i';
+                  $criteria[$name.'.display']['$options'] = 'i';
                 }
 
                 $criterias[] = $criteria;
@@ -563,7 +563,7 @@ class Admin extends \Cockpit\AuthController {
                 $criteria[$name.'.address'] = ['$regex' => $filter];
                 
                 if (!$isMongoLite) {
-                  $criteria[$name]['$options'] = 'i';
+                  $criteria[$name.'.address']['$options'] = 'i';
                 }
 
                 $criterias[] = $criteria;


### PR DESCRIPTION
The mongolite+mongo merge has a bug. It currently adds the mongo option to the wrong field for collectionlink and location.
This PR adds the mongo options to the correct field. I am sorry that I created this bug :(