### PR TITLE
fixed broken entry view with lang param

### DIFF
--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -214,7 +214,7 @@
 
         if (this.languages.length) {
             this.lang = App.Utils.params('lang') || App.session.get('collections.entry.'+this.collection._id+'.lang', '');
-            if (!this.languages.includes(this.lang)) this.lang = '';
+            if (!this.languages.find(function(el){return el.code == $this.lang;})) this.lang = '';
         }
 
         // fill with default values

--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -214,6 +214,7 @@
 
         if (this.languages.length) {
             this.lang = App.Utils.params('lang') || App.session.get('collections.entry.'+this.collection._id+'.lang', '');
+            if (!this.languages.includes(this.lang)) this.lang = '';
         }
 
         // fill with default values

--- a/modules/Singletons/views/form.php
+++ b/modules/Singletons/views/form.php
@@ -243,7 +243,7 @@
 
             if (this.languages.length) {
                 this.lang = App.Utils.params('lang') || App.session.get('singletons.form.'+this.singleton._id+'.lang', '');
-                if (!this.languages.includes(this.lang)) this.lang = '';
+                if (!this.languages.find(function(el){return el.code == $this.lang;})) this.lang = '';
             }
 
             this.on('mount', function(){

--- a/modules/Singletons/views/form.php
+++ b/modules/Singletons/views/form.php
@@ -243,6 +243,7 @@
 
             if (this.languages.length) {
                 this.lang = App.Utils.params('lang') || App.session.get('singletons.form.'+this.singleton._id+'.lang', '');
+                if (!this.languages.includes(this.lang)) this.lang = '';
             }
 
             this.on('mount', function(){


### PR DESCRIPTION
I  have two languages. `default: English` and `de: Deutsch`. If I try to open an entry with the new lang param
`http://localhost:8080/cockpit/collections/entry/pages/5f92ce4b323938e4ab0002dd?lang=en`, I have empty entries and I have js errors.

```
(intermediate value)._.find(...) is undefined riot.js:2:5377
<view-ed391dc2> {lang ? _.find(languages,{code:lang}).label:App.$data.languageDefaultLabel}
```

This fix takes care about querying the default language and querying non existent languages.