### PR TITLE
better filenames

### DIFF
--- a/modules/Cockpit/module/assets.php
+++ b/modules/Cockpit/module/assets.php
@@ -35,7 +35,10 @@ $this->module('cockpit')->extend([
             $name = basename($file);
 
             // clean filename
-            $clean = uniqid().preg_replace('/[^a-zA-Z0-9-_\.]/','', str_replace(' ', '-', $name));
+            $filename = pathinfo($file, PATHINFO_FILENAME);
+            $ext = pathinfo($file, PATHINFO_EXTENSION);
+            $cleanFilename = preg_replace('/[^a-zA-Z0-9-_\.]/','', str_replace(' ', '-', $filename));
+            $clean = $cleanFilename.uniqid("_uid_").'.'.$ext;
             $path  = '/'.date('Y/m/d').'/'.$clean;
 
             $asset = [


### PR DESCRIPTION
before the filename started with a md5 hash and the original name came
afterwards. Now the original name comes first and is then followed by a
uid. I also made the uid explicitly visible with a prefix.

In the assets manager files are displayed based on their filename. With
this change this is improved too as now the sorting is based on the
original filename and not on the md5 hash. This has lead to some strange
ordering before.