### PR TITLE
Globally rename "csfr" to "csrf"

### DIFF
--- a/modules/Cockpit/Controller/Auth.php
+++ b/modules/Cockpit/Controller/Auth.php
@@ -26,9 +26,9 @@ class Auth extends \LimeExtra\Controller {
                 $data['user']  = '';
             }
 
-            if (!$this->app->helper('csfr')->isValid('login', $this->param('csfr'), true)) {
-                $this->app->trigger('cockpit.authentication.failed', [$data, 'Csfr validation failed']);
-                return ['success' => false, 'error' => 'Csfr validation failed'];
+            if (!$this->app->helper('csrf')->isValid('login', $this->param('csrf'), true)) {
+                $this->app->trigger('cockpit.authentication.failed', [$data, 'Csrf validation failed']);
+                return ['success' => false, 'error' => 'Csrf validation failed'];
             }
 
             $user = $this->module('cockpit')->authenticate($data);
@@ -38,7 +38,7 @@ class Auth extends \LimeExtra\Controller {
             }
 
             if ($user) {
-                
+
                 $this->app->trigger('cockpit.authentication.success', [&$user]);
                 $this->module('cockpit')->setUser($user);
 

--- a/modules/Cockpit/Helper/Csrf.php
+++ b/modules/Cockpit/Helper/Csrf.php
@@ -13,16 +13,16 @@ namespace Cockpit\Helper;
 
 use Firebase\JWT\JWT;
 
-class Csfr extends \Lime\Helper {
+class Csrf extends \Lime\Helper {
 
     public function initialize(){
 
-        
+
     }
 
     public function generateToken($key, $expire = null) {
 
-        $payload = ['csfr' => $key];
+        $payload = ['csrf' => $key];
 
         if ($expire && is_numeric($expire)) {
             $payload['exp'] = $expire;
@@ -30,14 +30,14 @@ class Csfr extends \Lime\Helper {
 
         $token = JWT::encode($payload, $this->app['sec-key']);
 
-        $this->app->helper('session')->write("cockpit.csfr.token.{$key}", $token);
+        $this->app->helper('session')->write("cockpit.csrf.token.{$key}", $token);
 
         return $token;
     }
 
     public function token($key, $generate = false, $expire = null) {
 
-        $token = $this->app->helper('session')->read("cockpit.csfr.token.{$key}", null);
+        $token = $this->app->helper('session')->read("cockpit.csrf.token.{$key}", null);
 
         if (!$token || $generate) {
             $token = $this->generateToken($key, $expire);
@@ -55,13 +55,13 @@ class Csfr extends \Lime\Helper {
         if ($checkpayload) {
             try {
                 $payload = JWT::decode($token, $this->app['sec-key'], ['HS256']);
-                return isset($payload->csfr) && $payload->csfr == $key;
+                return isset($payload->csrf) && $payload->csrf == $key;
             } catch(\Exception $e) {
                 return false;
             }
         }
 
-        $stoken = $this->app->helper('session')->read("cockpit.csfr.token.{$key}", null);
+        $stoken = $this->app->helper('session')->read("cockpit.csrf.token.{$key}", null);
 
         if ($token != $stoken) {
             return false;

--- a/modules/Cockpit/admin.php
+++ b/modules/Cockpit/admin.php
@@ -16,7 +16,7 @@
 include(__DIR__.'/Helper/Admin.php');
 
 $app->helpers['admin'] = 'Cockpit\\Helper\\Admin';
-$app->helpers['csfr']  = 'Cockpit\\Helper\\Csfr';
+$app->helpers['csrf']  = 'Cockpit\\Helper\\Csrf';
 
 // init + load i18n
 $app->on('before', function() {

--- a/modules/Cockpit/views/_partials/logincheck.php
+++ b/modules/Cockpit/views/_partials/logincheck.php
@@ -1,7 +1,7 @@
 <div id="loginmodal" class="uk-modal" riot-view>
 
     <style>
-        .uk-modal-login { 
+        .uk-modal-login {
             max-width: 400px;
             padding: 30px;
         }
@@ -79,7 +79,7 @@
 
             App.request('/auth/check', {
                 auth : {user:this.refs.user.value, password:this.refs.password.value},
-                csfr : "{{ $app('csfr')->token('login') }}"
+                csrf : "{{ $app('csrf')->token('login') }}"
             }).then(function(data) {
 
                 if (data && data.success) {

--- a/modules/Cockpit/views/layouts/login.php
+++ b/modules/Cockpit/views/layouts/login.php
@@ -112,7 +112,7 @@
 
                 App.request('/auth/check', {
                     auth : {user:this.refs.user.value, password:this.refs.password.value },
-                    csfr : "{{ $app('csfr')->token('login') }}"
+                    csrf : "{{ $app('csrf')->token('login') }}"
                 }).then(function(data) {
 
                     if (data && data.success) {


### PR DESCRIPTION
I noticed a misspelling in the acronym currently used to denote [Cross Site Request Forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery) tokens.

**Related files:**

- https://github.com/agentejo/cockpit/search?q=csrf
- https://github.com/agentejo/cockpit/search?q=csfr


**Related commits:**

- [add CSRF protection to login form](https://github.com/agentejo/cockpit/commit/77fb722e53e42a7b42f1ef5d899bcac970f6ac69)
- [more work on csfr token support](https://github.com/agentejo/cockpit/commit/93bc174f1061c4ab858cfc4f43323a7c33496ce6)

_Have a nice Day,
Raruto_