### PR TITLE
Return null instead of empty string

### DIFF
--- a/modules/Collections/bootstrap.php
+++ b/modules/Collections/bootstrap.php
@@ -325,7 +325,7 @@ $this->module('collections')->extend([
                     }
 
                     if (!isset($entry[$field['name']])) {
-                        $value = $field['default'] ?? null;
+                        $value = !empty($field['default']) ? $field['default'] : null;
                     } else {
                         $value = $entry[$field['name']];
                     }
@@ -334,37 +334,33 @@ $this->module('collections')->extend([
 
                         case 'string':
                         case 'text':
-                            $value = (string)$value;
+                            $value = strlen($value) ? (string)$value : null;
                             break;
 
                         case 'boolean':
-
                             if ($value === 'true' || $value === 'false') {
-                                $value = $value === 'true' ? true:false;
+                                $value = $value === 'true' ? true : false;
                             } else {
                                 $value = $value ? true:false;
                             }
-
                             break;
 
                         case 'number':
-                            $value = is_numeric($value) ? $value:0;
+                            $value = is_numeric($value) ? $value : null;
                             break;
 
                         case 'url':
-                            $value = filter_var($value, FILTER_VALIDATE_URL) ? $value:null;
+                            $value = filter_var($value, FILTER_VALIDATE_URL) ? $value : null;
                             break;
 
                         case 'email':
-                            $value = $this->app->helper('utils')->isEmail($value) ? $value:null;
+                            $value = $this->app->helper('utils')->isEmail($value) ? $value : null;
                             break;
 
                         case 'password':
-
                             if ($value) {
                                 $value = $this->app->hash($value);
                             }
-
                             break;
                     }
 


### PR DESCRIPTION
When using the api to fetch data, in every field type an empty string is returned instead of null. 

This will only fix newly created content, as existing content will already have the empty string saved.

Solves: #1232 