### PR TITLE
Set default langauge for "admin" user during app install.

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -79,7 +79,7 @@ if (!count($failed)) {
         'active'   => true,
         'group'    => 'admin',
         'password' => $app->hash('admin'),
-        'i18n'     => 'en',
+        'i18n'     => $app->helper('i18n')->locale,
         '_created' => $created,
         '_modified'=> $created,
     ];


### PR DESCRIPTION
Currently a default language is already set for new accounts created via the admin dashboard:

https://github.com/agentejo/cockpit/blob/f024ee64356d2bb0fbde1a8fbf4ba991fa889c9b/modules/Cockpit/Controller/Accounts.php#L75

_Have a nice Day,
Raruto_