### PR TITLE
Update php version (7.3.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
         libssl-dev \
     && pecl install mongodb \
     && pecl install redis \
-    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) iconv gd pdo zip opcache pdo_sqlite \
     && a2enmod rewrite expires
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7.3-apache
 
 RUN apt-get update \
     && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Requirements
 
-* PHP >= 7.0
+* PHP >= 7.1
 * PDO + SQLite (or MongoDB)
 * GD extension
 * mod_rewrite, mod_versions enabled (on apache)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Requirements
 
-* PHP >= 7.1
+* PHP >= 7.3
 * PDO + SQLite (or MongoDB)
 * GD extension
 * mod_rewrite, mod_versions enabled (on apache)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
 
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.3.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "phpmailer/phpmailer": "^6.0",

--- a/install/index.php
+++ b/install/index.php
@@ -36,7 +36,7 @@ function ensure_writable($path) {
 
 // misc checks
 $checks = array(
-    'Php version >= 7.1.0'                              => (version_compare(PHP_VERSION, '7.1.0') >= 0),
+    'Php version >= 7.3.0'                              => (version_compare(PHP_VERSION, '7.3.0') >= 0),
     'Missing PDO extension with Sqlite support'         => $sqlitesupport,
     'GD extension not available'                        => extension_loaded('gd'),
     'MBString extension not available'                  => extension_loaded('mbstring'),


### PR DESCRIPTION
Update php version according to installation checks:

https://github.com/agentejo/cockpit/blob/722393b31921d5b3ee5992ade63ee9589f5b52a8/install/index.php#L39

---

**Additional info:**

- **version 7.3** will reach [end of life](https://www.php.net/supported-versions.php) in December 2021
- **version 8.0** has just been [released](https://www.php.net/releases/8.0/en.php) (with [nullsafe operator](https://www.php.net/releases/8.0/en.php#nullsafe-operator) and [named arguments](https://www.php.net/releases/8.0/en.php#named-arguments) support)

_Have a nice Day,
Raruto_
