### PR TITLE
Cleaner forms submit logic

### DIFF
--- a/modules/Forms/admin.php
+++ b/modules/Forms/admin.php
@@ -34,7 +34,7 @@ $app->on('admin.init', function() {
 
     if ($active) {
         $this->helper('admin')->favicon = 'forms:icon.svg';
-    } 
+    }
 
     /**
      * listen to app search to filter forms
@@ -78,6 +78,7 @@ $app->on('admin.init', function() {
             'forms.save.before.{$name}',
             'forms.submit.after',
             'forms.submit.before',
+            'forms.submit.email',
         ] as &$evt) { $triggers[] = $evt; }
     });
 

--- a/modules/Forms/views/api/email.php
+++ b/modules/Forms/views/api/email.php
@@ -1,0 +1,8 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+  @foreach($data as $key => $value)
+    <p><strong>{{ $key }}:</strong> {{ (is_string($value) ? $value : json_encode($value)) }}</p>
+  @endforeach
+</body>
+</html>


### PR DESCRIPTION
**List of changes:**

- added `'forms.submit.email'` event to allow finer filtering of sent emails (eg. to avoid creating a specific template for each newly created form):

```php
// Filter email content

$this->app->trigger('forms.submit.email', [$form, &$data, $frm, &$body, &$options]);
```
- added `&$response` parameter to `'forms.submit.after` event to allow finer filtering of returned data (I don't really like [phpmailer errors](https://github.com/agentejo/cockpit/blob/722393b31921d5b3ee5992ade63ee9589f5b52a8/modules/Forms/bootstrap.php#L309)  being [sent directly](https://github.com/agentejo/cockpit/blob/722393b31921d5b3ee5992ade63ee9589f5b52a8/modules/Forms/bootstrap.php#L321) to the browser)

```php
// Filter submission response

$this->app->trigger('forms.submit.after', [$form, &$data, $frm, &$response]);
```

-  replace `$this->app->renderer->file` with `$this->app->view` (to allow access to app [viewvars](https://github.com/agentejo/cockpit/blob/722393b31921d5b3ee5992ade63ee9589f5b52a8/lib/Lime/App.php#L107) in email templates)

```php
// Load custom email template

if ($template = $this->app->path("#config:forms/emails/{$form}.php")) {
    $body = $this->app->view($template, ['data' => $data, 'frm' => $frm]);
}
```

- added a default `modules/Forms/views/api/email.php` template (also useful for help people understand how to create their owns)

**TODO:**

I just discovered the existence of this method [PHPMailer::validateAddress($address, $patternselect)](https://github.com/PHPMailer/PHPMailer/blob/fa9c13cefdc9349c045fd13603533f61474984ed/src/PHPMailer.php#L1311), maybe this section could be further simplified?

https://github.com/agentejo/cockpit/blob/722393b31921d5b3ee5992ade63ee9589f5b52a8/modules/Forms/bootstrap.php#L271-L280