### PR TITLE
Add simple phpunit tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/phpcs.xml.dist export-ignore
+/tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ package-lock.json
 /storage/*.*
 /storage/*/*
 /config/*
-/tests/*
 /node_modules
 addons/
 !.gitignore

--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,9 @@
     "config": {
         "vendor-dir": "lib/vendor",
         "optimize-autoloader": true
+    },
+
+    "require-dev": {
+        "phpunit/phpunit": "7"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
+         bootstrap="bootstrap.php"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         colors="true"
+         cacheResult="false"
+         verbose="true">
+  <php>
+    <ini name="display_errors" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Cockpit Modules">
+        <directory>tests/modules</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
-         bootstrap="bootstrap.php"
+         bootstrap="tests/bootstrap.php"
          forceCoversAnnotation="true"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
@@ -11,6 +11,7 @@
          verbose="true">
   <php>
     <ini name="display_errors" value="true"/>
+    <const name="COCKPIT_PHPUNIT" value="true" />
   </php>
   <testsuites>
     <testsuite name="Cockpit Modules">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,17 @@
 <?php
+/**
+ * Make use of Cockpit autoloader to include it's own librararies.
+ *
+ * usage: open terminal and run { ./lib/vendor/bin/phpunit/ }
+ *
+ * @see https://phpunit.readthedocs.io/en/8.3/configuration.html#appendixes-configuration-phpunit-bootstrap
+ */
 
-declare(strict_types=1);
+/**
+ * @see { phpunit.xml.dist }
+ */
+if (!defined('COCKPIT_PHPUNIT') || !COCKPIT_PHPUNIT ) {
+    exit('Something goes wrong');
+}
 
 require_once __DIR__ . '/../bootstrap.php';

--- a/tests/modules/FormsTest.php
+++ b/tests/modules/FormsTest.php
@@ -1,0 +1,109 @@
+<?php
+namespace CockpitTests\Test;
+
+use PHPUnit\Framework\TestCase;
+
+class FormsTest extends TestCase {
+
+      protected static $mockFormId;
+
+      protected static $mockFormData;
+
+      // Generate uniqe form id before starting tests
+      public static function setUpBeforeClass() {
+          static::$mockFormId   = 'test-'.uniqid();
+          static::$mockFormData = [
+            ['uid' => uniqid(), 'email' => 'mock1@example.com'],
+            ['uid' => uniqid(), 'email' => 'mock2@example.com'],
+            ['uid' => uniqid(), 'email' => 'mock3@example.com']
+          ];
+      }
+
+      // Create "test" form before each test
+      protected function setUp() {
+          cockpit('forms:createForm', static::$mockFormId);
+          foreach (static::$mockFormData as $data) {
+            cockpit('forms:save', static::$mockFormId, $data);
+          }
+      }
+
+      // Delete "test" form after each test
+      protected function tearDown() {
+          cockpit('forms:removeForm', static::$mockFormId);
+      }
+
+      // Clean things after all tests have been executed
+      public static function tearDownAfterClass() {
+      }
+
+      public function testExits() {
+        $path = cockpit('forms:exists', static::$mockFormId);
+        $this->assertTrue(!empty($path));
+      }
+
+      public function testUpdateForm() {
+        $form = cockpit('forms:updateForm', static::$mockFormId, ['label' => 'hello']);
+        $this->assertTrue($form['label'] === 'hello');
+      }
+
+      public function testSaveForm() {
+        $data  = ['_id' => static::$mockFormId, 'label' => 'hello'];
+        $saved = cockpit('forms:saveForm', static::$mockFormId, $data);
+        $this->assertTrue($saved['label'] === 'hello');
+      }
+
+      public function testRemoveForm() {
+        $removed = cockpit('forms:removeForm', static::$mockFormId);
+        $this->assertTrue($removed);
+      }
+
+      public function testForms() {
+        $forms = cockpit('forms:forms', static::$mockFormId.'-'.uniqid());
+        $this->assertTrue(!empty($forms) && is_array($forms));
+      }
+
+      public function testForm() {
+        $form = cockpit('forms:form', static::$mockFormId);
+        $this->assertTrue(!empty($form) && $form['_id'] === static::$mockFormId);
+      }
+
+      public function testEntries() {
+        $entries = cockpit('forms:entries', static::$mockFormId);
+        $this->assertTrue($entries instanceof \MongoLite\Collection);
+      }
+
+      public function testFind() {
+        $entries = cockpit('forms:find', static::$mockFormId);
+        $this->assertTrue(count($entries) === count(static::$mockFormData));
+      }
+
+      public function testFindOne() {
+        $criteria = [ 'uid' => static::$mockFormData[0]['uid'] ];
+        $entry    = cockpit('forms:findOne', static::$mockFormId);
+        $this->assertTrue($entry['uid'] === $criteria['uid']);
+      }
+
+      public function testSave() {
+        $data  = ['uid' => uniqid(), 'email' => 'hello@example.com'];
+        $saved = cockpit('forms:save', static::$mockFormId, $data);
+        $this->assertTrue($saved['uid'] === $data['uid'] && $saved['email'] === $data['email']);
+      }
+
+      public function testRemove() {
+        $criteria = [ 'uid' => static::$mockFormData[0]['uid'] ];
+        $removed  = cockpit('forms:remove', static::$mockFormId, $criteria);
+        $this->assertTrue($removed === 1);
+      }
+
+      public function testCount() {
+        $entries = cockpit('forms:count', static::$mockFormId);
+        $this->assertTrue($entries === count(static::$mockFormData));
+      }
+
+      public function testSubmit() {
+        $data     = ['uid' => uniqid(), 'email' => 'hello@example.com'];
+        $response = cockpit('forms:submit', static::$mockFormId, $data);
+        $this->assertTrue($response === $data);
+      }
+
+}

--- a/tests/modules/FormsTest.php
+++ b/tests/modules/FormsTest.php
@@ -1,18 +1,25 @@
 <?php
+declare(strict_types=1);
+
 namespace CockpitTests\Test;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Test Cockpit's \Forms
+ */
 class FormsTest extends TestCase {
 
+      /** @var string - Mock Form id **/
       protected static $mockFormId;
 
-      protected static $mockFormData;
+      /** @var array - Mock Form items **/
+      protected static $mockFormItems;
 
       // Generate uniqe form id before starting tests
       public static function setUpBeforeClass() {
           static::$mockFormId   = 'test-'.uniqid();
-          static::$mockFormData = [
+          static::$mockFormItems = [
             ['uid' => uniqid(), 'email' => 'mock1@example.com'],
             ['uid' => uniqid(), 'email' => 'mock2@example.com'],
             ['uid' => uniqid(), 'email' => 'mock3@example.com']
@@ -22,7 +29,7 @@ class FormsTest extends TestCase {
       // Create "test" form before each test
       protected function setUp() {
           cockpit('forms:createForm', static::$mockFormId);
-          foreach (static::$mockFormData as $data) {
+          foreach (static::$mockFormItems as $data) {
             cockpit('forms:save', static::$mockFormId, $data);
           }
       }
@@ -36,70 +43,109 @@ class FormsTest extends TestCase {
       public static function tearDownAfterClass() {
       }
 
+      /**
+       * @covers \Forms::exists
+       */
       public function testExits() {
         $path = cockpit('forms:exists', static::$mockFormId);
         $this->assertTrue(!empty($path));
       }
 
+      /**
+       * @covers \Forms::UpdateForm
+       */
       public function testUpdateForm() {
         $form = cockpit('forms:updateForm', static::$mockFormId, ['label' => 'hello']);
         $this->assertTrue($form['label'] === 'hello');
       }
 
+      /**
+       * @covers \Forms::saveForm
+       */
       public function testSaveForm() {
         $data  = ['_id' => static::$mockFormId, 'label' => 'hello'];
         $saved = cockpit('forms:saveForm', static::$mockFormId, $data);
         $this->assertTrue($saved['label'] === 'hello');
       }
 
+      /**
+       * @covers \Forms::removeForm
+       */
       public function testRemoveForm() {
         $removed = cockpit('forms:removeForm', static::$mockFormId);
         $this->assertTrue($removed);
       }
 
+      /**
+       * @covers \Forms::forms
+       */
       public function testForms() {
         $forms = cockpit('forms:forms', static::$mockFormId.'-'.uniqid());
         $this->assertTrue(!empty($forms) && is_array($forms));
       }
 
+      /**
+       * @covers \Forms::form
+       */
       public function testForm() {
         $form = cockpit('forms:form', static::$mockFormId);
         $this->assertTrue(!empty($form) && $form['_id'] === static::$mockFormId);
       }
 
+      /**
+       * @covers \Forms::entries
+       */
       public function testEntries() {
         $entries = cockpit('forms:entries', static::$mockFormId);
         $this->assertTrue($entries instanceof \MongoLite\Collection);
       }
 
+      /**
+       * @covers \Forms::find
+       */
       public function testFind() {
         $entries = cockpit('forms:find', static::$mockFormId);
-        $this->assertTrue(count($entries) === count(static::$mockFormData));
+        $this->assertTrue(count($entries) === count(static::$mockFormItems));
       }
 
+      /**
+       * @covers \Forms::findOne
+       */
       public function testFindOne() {
-        $criteria = [ 'uid' => static::$mockFormData[0]['uid'] ];
+        $criteria = [ 'uid' => static::$mockFormItems[0]['uid'] ];
         $entry    = cockpit('forms:findOne', static::$mockFormId);
         $this->assertTrue($entry['uid'] === $criteria['uid']);
       }
 
+      /**
+       * @covers \Forms::save
+       */
       public function testSave() {
         $data  = ['uid' => uniqid(), 'email' => 'hello@example.com'];
         $saved = cockpit('forms:save', static::$mockFormId, $data);
         $this->assertTrue($saved['uid'] === $data['uid'] && $saved['email'] === $data['email']);
       }
 
+      /**
+       * @covers \Forms::remove
+       */
       public function testRemove() {
-        $criteria = [ 'uid' => static::$mockFormData[0]['uid'] ];
+        $criteria = [ 'uid' => static::$mockFormItems[0]['uid'] ];
         $removed  = cockpit('forms:remove', static::$mockFormId, $criteria);
         $this->assertTrue($removed === 1);
       }
 
+      /**
+       * @covers \Forms::count
+       */
       public function testCount() {
         $entries = cockpit('forms:count', static::$mockFormId);
-        $this->assertTrue($entries === count(static::$mockFormData));
+        $this->assertTrue($entries === count(static::$mockFormItems));
       }
 
+      /**
+       * @covers \Forms::submit
+       */
       public function testSubmit() {
         $data     = ['uid' => uniqid(), 'email' => 'hello@example.com'];
         $response = cockpit('forms:submit', static::$mockFormId, $data);


### PR DESCRIPTION
I have created some really simple tests for the [Forms](https://github.com/agentejo/cockpit/blob/722393b31921d5b3ee5992ade63ee9589f5b52a8/modules/Forms/bootstrap.php) module (hoping this can serve as a starting point for other critical parts as well...)

---

**List of changes:**

- add `.gitattributes` files in order to exclude the tests folder from releases
- remove `tests` folder from `.gitignore` files 
- require `phpunit ^7` as `composer.json` dev dependecy
- add `phpunit.xml.dist` and `tests/bootstrap.php` autoloader
- add `tests/modules/FormsTest.php` test file

---

**Useful links:**

- [piotr-cz/cockpit-sql-driver](https://github.com/piotr-cz/cockpit-sql-driver/tree/dac71d1c9e4368aec869088121631295441260a2) for sample database tests
- [PHPMailer/PHPMailer](https://github.com/PHPMailer/PHPMailer/tree/640e68d33218e9886ec700b058613d5552cb31fe) for sample email tests
- [Getting started with PHPUnit 7](https://phpunit.de/getting-started/phpunit-7.html)
- [PHPUnit Manual](https://phpunit.readthedocs.io/en/9.5/)

_Happy Testing,
Raruto_
