### PR TITLE
Fix "Forms::entries" throws undefined "getform" method in "MongoHybrid\MongoLite"

### DIFF
--- a/modules/Forms/bootstrap.php
+++ b/modules/Forms/bootstrap.php
@@ -152,7 +152,7 @@ $this->module('forms')->extend([
 
         $form = $forms['_id'];
 
-        return $this->app->storage->getform("forms/{$form}");
+        return $this->app->storage->getCollection("forms/{$form}");
     },
 
     'find' => function($form, $options = []) {


### PR DESCRIPTION
Related to: https://github.com/agentejo/cockpit/pull/1406

---

**phpunit log:**

```log
1) CockpitTests\Test\FormsTest::testEntries
call_user_func_array() expects parameter 1 to be a valid callback, class 'MongoHybrid\MongoLite' does not have a method 'getform'

D:\htdocs\cockpit\lib\MongoHybrid\Client.php:425
D:\htdocs\cockpit\modules\Forms\bootstrap.php:155
D:\htdocs\cockpit\lib\Lime\App.php:1260
D:\htdocs\cockpit\bootstrap.php:292
D:\htdocs\cockpit\tests\modules\FormsTest.php:99

ERRORS!
Tests: 13, Assertions: 12, Errors: 1.
```

---

**CockpitTests\Test\FormsTest::testEntries**

```php
/**
 * @covers \Forms::entries
 */
public function testEntries() {
  $entries = cockpit('forms:entries', static::$mockFormId);
  $this->assertTrue($entries instanceof \MongoLite\Collection);
}
```

---

**Forms::entries**

```php
// modules/forms/bootstrap.php#L147

'entries' => function($name) {

  $forms = $this->form($name);

  if (!$forms) return false;

  $form = $forms['_id'];

  return $this->app->storage->getform("forms/{$form}"); // <-- getform is undefined in "MongoHybrid\MongoLite"
},
```

_Have a nice Day,
Raruto_