### PR TITLE
Add the possibility to translate field label in collections

### DIFF
--- a/modules/Collections/views/entry.php
+++ b/modules/Collections/views/entry.php
@@ -93,7 +93,7 @@
 
                             <label title="{ field.name }">
 
-                                <span class="uk-text-bold"><i class="uk-icon-pencil-square uk-margin-small-right"></i> { field.label || App.Utils.ucfirst(field.name) }</span>
+                                <span class="uk-text-bold"><i class="uk-icon-pencil-square uk-margin-small-right"></i> { App.i18n.get(field.label) || field.label } </span>
                                 <span class="uk-text-muted" show="{field.required}">&mdash; @lang('required')</span>
 
                                 <span if="{ field.localize }" data-uk-dropdown="mode:'click'">


### PR DESCRIPTION
Issue #1415 

In this commit only collection field label is edited, but i think it is an good idea to add to other type of items