### PR TITLE
Fix Lexy "@include" prints 1 after included file

### DIFF
--- a/lib/LimeExtra/App.php
+++ b/lib/LimeExtra/App.php
@@ -54,7 +54,7 @@ class App extends \Lime\App {
                     'url'      => '<?php echo $app->pathToUrl(expr); ?>',
                     'view'     => '<?php echo $app->view(expr); ?>',
                     'render'   => '<?php echo $app->view(expr); ?>',
-                    'include'  => '<?php echo include($app->path(expr)); ?>',
+                    'include'  => '<?php include($app->path(expr)); ?>',
                     'lang'     => '<?php echo $app("i18n")->get(expr); ?>',
                 ];
 


### PR DESCRIPTION
Calling:

```blade
@include('foo.php')
```

renders as:

```
.. foo content ..

1
```

It may be intended behavior, but given previous [commit](https://github.com/agentejo/cockpit/commit/d50c01b048984d4efe1d8e1f63adbb24be8cdb12) history for [`vendor/LimeExtra/App.php`](https://github.com/agentejo/cockpit/blob/b0bd8e19f6c92fc035a191c24d4972cdfee01375/vendor/LimeExtra/App.php#L40), I think it's an oversight 

---

**Additional notes:**

- [php include prints 1](https://stackoverflow.com/questions/5086695/php-include-prints-1/48742686)

_Have a nice day,
Raruto_