### PR TITLE
Allow modified date to be updated with API

### DIFF
--- a/modules/Collections/bootstrap.php
+++ b/modules/Collections/bootstrap.php
@@ -313,7 +313,7 @@ $this->module('collections')->extend([
 
             $isUpdate = isset($entry['_id']);
 
-            $entry['_modified'] = $modified;
+            $entry['_modified'] = isset($entry['_modified']) ? $entry['_modified'] : $modified;
 
             if (isset($_collection['fields'])) {
 

--- a/modules/Collections/bootstrap.php
+++ b/modules/Collections/bootstrap.php
@@ -313,7 +313,7 @@ $this->module('collections')->extend([
 
             $isUpdate = isset($entry['_id']);
 
-            $entry['_modified'] = isset($entry['_modified']) ? $entry['_modified'] : $modified;
+            $entry['_modified'] = isset($entry['_uModified']) ? $entry['_uModified'] : $modified;
 
             if (isset($_collection['fields'])) {
 


### PR DESCRIPTION
It would be nice to be able to update the `_modified` value with the API. 

This comes handy when migrating data from a different CMS in order to keep the same history.

The param has to be named different from `_modified`, otherwise it will conflict when updating the entry in the backend.