### PR TITLE
Catch error that is thrown when filter call fails to start

### DIFF
--- a/modules/Collections/assets/import/filter.js
+++ b/modules/Collections/assets/import/filter.js
@@ -139,6 +139,10 @@
                             console.log("Couldn't find a collection reference for "+value);
                             $this.resolve(null);
                         }
+                    })
+                    .catch(() => {
+                        console.log("Couldn't find a collection reference for "+value);
+                        $this.resolve(null);
                     });
 
                 }


### PR DESCRIPTION
This otherwise will block all following calls from starting. This errors often when importing large amounts of data.