### PR TITLE
Enhance tags field type

### DIFF
--- a/modules/Cockpit/assets/components.js
+++ b/modules/Cockpit/assets/components.js
@@ -4184,37 +4184,99 @@ riot.tag2('field-set', '<div> <div class="uk-alert" if="{fields && !fields.lengt
 
 });
 
-riot.tag2('field-tags', '<div class="uk-grid uk-grid-small uk-flex-middle" data-uk-grid-margin="observe:true"> <div class="uk-text-primary" each="{_tag,idx in _tags}"> <span class="field-tag"><i class="uk-icon-tag"></i> {_tag} <a onclick="{parent.remove}"><i class="uk-icon-close"></i></a></span> </div> <div show="{allowInput}"> <div ref="autocomplete" class="uk-autocomplete uk-form-icon uk-form"> <i class="uk-icon-tag"></i> <input ref="input" class="uk-width-1-1 uk-form-blank" type="text" placeholder="{App.i18n.get(opts.placeholder || \'Add Tag...\')}"> </div> </div> </div>', 'field-tags .field-tag,[data-is="field-tags"] .field-tag{ display: inline-block; border: 1px currentColor solid; padding: .4em .5em; font-size: .9em; border-radius: 3px; line-height: 1; }', '', function(opts) {
+riot.tag2('field-tags', '<div if="{loading}"><i class="uk-icon-spinner uk-icon-spin"></i></div> <div show="{!loading}" class="uk-grid uk-grid-small uk-flex-middle" data-uk-grid-margin="observe:true"> <div class="uk-text-primary" each="{_tag,idx in _tags}"> <span class="field-tag"><i class="uk-icon-tag"></i> {_tag} <a onclick="{parent.remove}"><i class="uk-icon-close"></i></a></span> </div> <div show="{allowInput}"> <div ref="autocomplete" class="uk-autocomplete uk-form-icon uk-form"> <i class="uk-icon-tag"></i> <input ref="input" class="uk-width-1-1 uk-form-blank" type="text" placeholder="{App.i18n.get(opts.placeholder || \'Add Tag...\')}"> </div> </div> </div>', 'field-tags .field-tag,[data-is="field-tags"] .field-tag{ display: inline-block; border: 1px currentColor solid; padding: .4em .5em; font-size: .9em; border-radius: 3px; line-height: 1; }', '', function(opts) {
 
         var $this = this;
 
         this._tags = [];
         this.allowInput = true;
+        this.autocompleteOptions = [];
+        this.loading = 0;
 
         this.on('mount', function(){
-            this.update()
-        });
-
-        this.on('update', function(){
-
-            if ($this.opts.limit) {
-                $this.allowInput = $this._tags.length < $this.opts.limit;
+            var _source = [];
+            if (Array.isArray(opts.autocomplete) && opts.autocomplete.length && !opts.autocomplete[0].value) {
+                opts.autocomplete.forEach(function(value) {
+                    $this.autocompleteOptions.push({value: value});
+                });
+            } else if(opts.autocomplete) {
+                _source = opts.autocomplete;
             }
 
-            if (opts.autocomplete) {
+            $this.autocomplete = UIkit.autocomplete(this.refs.autocomplete, {
+                source: _source,
+                delay: typeof opts.delay === "number" ? opts.delay : undefined,
+                minLength: typeof opts.minLength === "number" ? opts.minLength : 1
+            });
 
-                var _source = opts.autocomplete;
+            var sources = [];
+            if (Array.isArray(opts.src)) {
+                sources = opts.src;
+            } else if (opts.src && opts.src.url && opts.src.value) {
+                sources.push(opts.src);
+            }
 
-                if (Array.isArray(opts.autocomplete) && opts.autocomplete.length && !opts.autocomplete[0].value) {
+            sources.forEach(function (src) {
+                if (src && src.url && src.value) {
 
-                    _source = [];
+                    $this.loading++;
 
-                    opts.autocomplete.forEach(function(val) {
-                        _source.push({value:val})
+                    var url = src.url;
+                    var fieldVal = src.value;
+
+                    if (url.match('^collection=')) {
+                        url = '/collections/find?' + url;
+                    }
+
+                    App.request(url).then(function (data) {
+
+                        $this.loading--;
+
+                        if (url.match('^\/collections\/find\?')) {
+                            data = data.entries;
+                        }
+
+                        if (!Array.isArray(data)) {
+                            $this.update();
+                            return;
+                        }
+
+                        data.forEach(function (item) {
+                            var value = _.get(item, fieldVal);
+                            if (Array.isArray(value)) {
+                                value.forEach(function (val) {
+                                    $this.autocompleteOptions.push({value: val});
+                                });
+                            } else if (typeof value == "string") {
+                                $this.autocompleteOptions.push({value: value});
+                            }
+                        });
+
+                        $this.update();
                     })
                 }
 
-                UIkit.autocomplete(this.refs.autocomplete, {source: _source, minLength: opts.minLength || 1});
+            });
+
+            if (opts.minLength === 0) {
+                this.refs.input.onfocus = function(e) {
+                    $this.autocomplete.handle();
+                    $this.autocomplete.show();
+                };
+            }
+
+            this.update();
+        });
+
+        this.on('update', function(){
+            if ($this.autocomplete && $this.autocompleteOptions.length > 0) {
+                $this.autocomplete.options.source = _.sortBy($this.autocompleteOptions, ["value"]);
+                $this.autocomplete.options.source = _.uniqBy($this.autocomplete.options.source, function (e) {return e.value});
+                $this.autocomplete.options.source = _.filter($this.autocomplete.options.source, function (e) { return $this._tags.indexOf(e.value) === -1;  });
+            }
+
+            if ($this.opts.limit) {
+                $this.allowInput = $this._tags.length < $this.opts.limit;
             }
 
             App.$(this.root).on({


### PR DESCRIPTION
We wanted to use the tags field type to share types between different collections and to have autocomplete suggestions from both collections.

To facilitate this, I added the following to field-tags in this PR:
* Loading autocomplete suggestions like select field type (for example to suggest tags used in other entries in same collection)
```
{
  "src": {
    "url": "collection=collection_1",
    "value": "tags"
  }
}
```
* Loading multiple sources (to share tags between collections)
```
{
  "src": [{
    "url": "collection=collection_1",
    "value": "tags"
  }, {
    "url": "collection=collection_2",
    "value": "tags"
  }]
}
```
* Setting minLength option to 0, ie. show autocompletions when focusing the input
* Setting autocomplete delay from option (used to filter options directly when using static list or from sources)
* Don't suggest tag already in use

This PR should be backwards compatible with specifying a URL in the autocomplete option if no sources are used.
