### PR TITLE
added a simple docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  cockpit:
+    build: .


### PR DESCRIPTION
I like to build my docker images with the command : 
`docker-compose up --build`
This simple docker-compose.yml file makes it possible to build the docker container with this command.
