### PR TITLE
Implemented select renderer

### DIFF
--- a/assets/app/js/app.utils.js
+++ b/assets/app/js/app.utils.js
@@ -331,6 +331,13 @@
         return '<span class="uk-badge">' + (cnt + (cnt == 1 ? ' Item' : ' Items')) + '</span>';
     };
 
+    App.Utils.renderer.select = function (v, field) {
+        if (field.options && field.options.options && field.options.options[v]) {
+            return '<span title="Value: ' + v + '" data-uk-tooltip>' + field.options.options[v] + '</span>';
+        }
+        return v;
+    };
+
     App.Utils.renderer.tags = App.Utils.renderer.multipleselect = function (v) {
 
         if (Array.isArray(v) && v.length > 1) {


### PR DESCRIPTION
Select fields doesn't currently have a special renderer and is therefore just printing it's raw value.
Since select can handle key-value options, it would be nice to present the label for the value if possible.

This PR implements just that, with a tooltip showing the raw value if hoovered:
![image](https://user-images.githubusercontent.com/51078938/121863624-554f0900-ccfc-11eb-95fc-b09dbe3833d4.png)
