### PR TITLE
Allow user to add reply-to option to mailer

### DIFF
--- a/modules/Forms/Controller/RestApi.php
+++ b/modules/Forms/Controller/RestApi.php
@@ -28,6 +28,9 @@ class RestApi extends \LimeExtra\Controller {
                 $options['subject'] = $this->param('__mailsubject');
             }
 
+            if ($this->param('__replyTo')) {
+                $options['reply_to'] = $this->param('__replyTo');
+            }
             return $this->module('forms')->submit($form, $data, $options);
         }
 


### PR DESCRIPTION
Added the option to set the reply-to mailer option through parameters in the Forms API.

Closes  #1453.