### PR TITLE
Fix (MongoLite): change disallowed character from ( to single quote '

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -290,7 +290,9 @@ class UtilArrayQuery {
 
                     $d = '$document';
 
-                    if (\strpos($key, '(') !== false) {
+                    // single quote ' would allow to break out of the `isset($document['$key'])` string
+                    // rel https://github.com/agentejo/cockpit/commit/b40d6bdedb87265e700ac09007603e72459e7629#commitcomment-53000630
+                    if (\strpos($key, '\'') !== false) {
                         throw new \InvalidArgumentException('Unallowed characters used in filter keys');
                     }
 


### PR DESCRIPTION
Single quotes would allow to break out of the later formed command string allowing any functions to be executed

rel: https://github.com/agentejo/cockpit/commit/b40d6bdedb87265e700ac09007603e72459e7629#commitcomment-53000630