### PR TITLE
fix (removeSingleton): remove singleton key also from DB

### DIFF
--- a/modules/Singletons/bootstrap.php
+++ b/modules/Singletons/bootstrap.php
@@ -101,6 +101,7 @@ $this->module('singletons')->extend([
         if ($singleton = $this->singleton($name)) {
 
             $this->app->helper('fs')->delete("#storage:singleton/{$name}.singleton.php");
+            $this->app->storage->removeKey('singletons', $name);
 
             $this->app->trigger('singleton.remove', [$singleton]);
             $this->app->trigger("singleton.remove.{$name}", [$singleton]);


### PR DESCRIPTION
## Bug 
Removing a singleton currently only removes the "singleton spec" file but not its fields data in the DB.

This causes old entries to repopulate a singleton after it was deleted and re-created with the same name and fields.

See also the discussion here https://discourse.getcockpit.com/t/entries-deleted-inside-cockpit-are-retained-in-api/1941/2?u=abernh

## Expected behavior
deleting a singleton should also delete all its data and re-creating it with the same fields should not show the old values of the previous singleton

## Fix
Calling `->storage->removeKey()` on the singleton on-remove solves the issue.