### PR TITLE
Improve cookie helper: add samesite parameter

### DIFF
--- a/lib/LimeExtra/App.php
+++ b/lib/LimeExtra/App.php
@@ -28,7 +28,7 @@ class App extends \Lime\App {
             'image'   => 'LimeExtra\\Helper\\Image',
             'i18n'    => 'LimeExtra\\Helper\\I18n',
             'utils'   => 'LimeExtra\\Helper\\Utils',
-            'coockie' => 'LimeExtra\\Helper\\Cookie',
+            'cookie'  => 'LimeExtra\\Helper\\Cookie',
             'yaml'    => 'LimeExtra\\Helper\\YAML',
         ], $settings['helpers'] ?? []);
 

--- a/lib/LimeExtra/Helper/Cookie.php
+++ b/lib/LimeExtra/Helper/Cookie.php
@@ -33,14 +33,14 @@ class Cookie extends \Lime\Helper {
      * @param bool $http_only
      * @param (string|null) $same_site
      * @return bool
-     * @throws Exception - throws Exception if SameSite=None and Secure=False
+     * @throws \Exception - throws Exception if SameSite=None and Secure=False
      */
     public function set($name, $value = "", $ttl = 86400 /* 1 day */, $path = '/', $domain = '', $secure = false, $http_only = false, $same_site = null)
     {
         if ($same_site && strtolower($same_site) === 'none' && !$secure) {
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#fixing_common_warnings
             // "SameSite=None" only if "Secure=True"
-            throw new Exception('"SameSite=None" only if "Secure=True"');
+            throw new \Exception('"SameSite=None" only if "Secure=True"');
         }
 
         $options = [

--- a/lib/LimeExtra/Helper/Cookie.php
+++ b/lib/LimeExtra/Helper/Cookie.php
@@ -31,11 +31,34 @@ class Cookie extends \Lime\Helper {
      * @param string $domain
      * @param bool $secure
      * @param bool $http_only
+     * @param (string|null) $same_site
      * @return bool
+     * @throws Exception - throws Exception if SameSite=None and Secure=False
      */
-    public function set($name, $value, $ttl = 86400 /* 1 day */, $path = '/', $domain = '', $secure = false, $http_only = false) {
-        $this->_cookies[$name] = $value;
-        $result = \setcookie($name, $value, time() + $ttl, $path, $domain, $secure, $http_only);
+    public function set($name, $value = "", $ttl = 86400 /* 1 day */, $path = '/', $domain = '', $secure = false, $http_only = false, $same_site = null)
+    {
+        if ($same_site && strtolower($same_site) === 'none' && !$secure) {
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#fixing_common_warnings
+            // "SameSite=None" only if "Secure=True"
+            throw new Exception('"SameSite=None" only if "Secure=True"');
+        }
+
+        $options = [
+            'expires' => time() + $ttl,
+            'path' => $path,
+            'domain' => $domain,
+            'secure' => $secure,
+            'httponly' => $http_only
+        ];
+        if($same_site){
+            $options['samesite'] = $same_site;
+        }
+
+        $result = \setcookie($name, $value, $options);
+
+        if ($result) {
+            $this->_cookies[$name] = $value;
+        }
 
         if (isset($this->_deleted_cookies[$name])) {
             unset($this->_deleted_cookies[$name]);
@@ -71,8 +94,8 @@ class Cookie extends \Lime\Helper {
      * @param string $name
      * @return bool
      */
-    public function delete($name, $path = '/', $domain = '', $secure = false, $http_only = false) {
-        $success = $this->set($name, null, -10, $path, $domain, $secure, $http_only);
+    public function delete($name, $path = '/', $domain = '', $secure = false, $http_only = false, $same_site = null) {
+        $success = $this->set($name, null, -10, $path, $domain, $secure, $http_only, $same_site);
         $this->_deleted_cookies[$name] = $name;
 
         if (isset($this->_cookies[$name])) {
@@ -88,9 +111,9 @@ class Cookie extends \Lime\Helper {
      * @param string $name
      * @return mixed
      */
-    public function getAndDelete($name, $path = '/', $domain = '', $secure = false, $http_only = false) {
+    public function getAndDelete($name, $path = '/', $domain = '', $secure = false, $http_only = false, $same_site = null) {
         $value = $this->get($name);
-        $this->delete($name, $path, $domain, $secure, $http_only);
+        $this->delete($name, $path, $domain, $secure, $http_only, $same_site);
 
         return $value;
     }

--- a/lib/LimeExtra/Helper/Cookie.php
+++ b/lib/LimeExtra/Helper/Cookie.php
@@ -58,10 +58,10 @@ class Cookie extends \Lime\Helper {
 
         if ($result) {
             $this->_cookies[$name] = $value;
-        }
 
-        if (isset($this->_deleted_cookies[$name])) {
-            unset($this->_deleted_cookies[$name]);
+            if (isset($this->_deleted_cookies[$name])) {
+                unset($this->_deleted_cookies[$name]);
+            }
         }
 
         return $result;


### PR DESCRIPTION
# Problem

With the current `Cookie::set()` method the parameter "samesite" can not be set for a cookie.

# Solution

Added additional parameter "samesite" and use the new  `setcookie(name, val, options)` (since PHP7.3) method

# Note

Also renamed misspelled `coockie` helper reference in `Lime\App`:
`'coockie' --> 'cookie'`