### PR TITLE
fix (Bug 1002:createMongoDbLikeId): microsecond float to big integer …

### DIFF
--- a/lib/MongoLite/Database.php
+++ b/lib/MongoLite/Database.php
@@ -542,7 +542,7 @@ function createMongoDbLikeId() {
     // Building binary data.
     $bin = \sprintf(
         '%s%s%s%s',
-        \pack('N', $timestamp),
+        \pack('N', $timestamp * 10000),
         \substr(md5(uniqid()), 0, 3),
         \pack('n', $processId),
         \substr(\pack('N', $id), 1, 3)


### PR DESCRIPTION
…before binary conversion

microseconds were omitted when using `pack` with format 'N',
causing timestamp to be reduced to "seconds",
causing high chances of equal IDs on import processes

Rel: Issue #1002
