### PR TITLE
Add stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v3
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In order to automatically handle inactive issues: 

- add a label "stale" on issues and pull requests after 30 days of inactivity and comment on them
- close the stale issues after 14 days of inactivity
- if an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart

**Reference:**
- [closing inactive issues](https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues)
- [actions/stale](https://github.com/actions/stale)

_Have a nice Day,
Raruto_