### PR TITLE
Bugfix entries batch edit localized fields

### DIFF
--- a/modules/Collections/assets/entries-batchedit.tag
+++ b/modules/Collections/assets/entries-batchedit.tag
@@ -130,8 +130,7 @@
             var required = [], field;
 
             Object.keys(this.checked).forEach(function(name){
-
-                field = $this.fields[name];
+                field = _.find($this._fields, {name: name});
 
                 if (field.required && !$this._entry[field.name]) {
 

--- a/modules/Collections/views/partials/entries.php
+++ b/modules/Collections/views/partials/entries.php
@@ -669,7 +669,11 @@
         }
 
         batchedit() {
-            this.tags['entries-batchedit'].open(this.entries, this.selected)
+            if (!this.lang) {
+                this.tags['entries-batchedit'].open(this.entries, this.selected);
+            } else {
+                App.ui.notify("Cannot batch edit while in non-default language", "danger");
+            }
         }
 
         changelanguage(e) {


### PR DESCRIPTION
Batch edit is broken in two different ways when working with entries with localized fields:

Since fields (in entries-batchedit.tag) does not contain the localized names, field will be null and the required fields code will have a NPE when saving. Localized fields are added to fields _fields and therefore those should be used to look for localized fields.

When batch editing entries with a selected language, the entries will have empty root fields overwritten by their the selected language field value. The easiest fix is to only allow batch editing while viewing entries in the default language.
The nice fix is to implement patch updating to collection entries and only change the provided fields.
I went for the easy fix this time ;)