### PR TITLE
Reordering sorted collection is missing a webhook

### DIFF
--- a/modules/Collections/Controller/Admin.php
+++ b/modules/Collections/Controller/Admin.php
@@ -398,6 +398,9 @@ class Admin extends \Cockpit\AuthController {
             }
         }
 
+        $this->app->trigger("collections.reorder", [$collection['name'], $entries]);
+        $this->app->trigger("collections.reorder.{$collection['name']}", [$collection['name'], $entries]);
+
         return $entries;
     }
 

--- a/modules/Collections/admin.php
+++ b/modules/Collections/admin.php
@@ -89,6 +89,8 @@ $app->on('admin.init', function() {
             'collections.remove.before.{$name}',
             'collections.removecollection',
             'collections.removecollection.{$name}',
+            'collections.reorder',
+            'collections.reorder.{$name}',
             'collections.save.after',
             'collections.save.after.{$name}',
             'collections.save.before',


### PR DESCRIPTION
Simple enough, this PR triggers "collection.reorder" and "collections.reorder.{$name}" when a sorted collection is reordered