### PR TITLE
japanese language support in wysiwyg renderer

### DIFF
--- a/assets/app/js/app.utils.js
+++ b/assets/app/js/app.utils.js
@@ -365,7 +365,15 @@
 
     App.Utils.renderer.wysiwyg = function (v) {
         v = App.Utils.stripTags(v);
-        return v.length < 50 ? v : App.$.trim(v).substring(0, 50).split(' ').slice(0, -1).join(' ') + '...';
+        if (v.length < 50) {
+            return v;
+        }
+        var splitted_str = App.$.trim(v).substring(0, 50).split(' ');
+        if (splitted_str.length > 2) {
+            return splitted_str.slice(0, -1).join(' ') + '...';
+        } else {
+            return splitted_str.join(' ') + ' ...';
+        }
     };
 
     App.Utils.renderer.text = function (v) {


### PR DESCRIPTION
When I try to view information in the wysiwyg editor written in Japanese on the list of entries page, it only shows "...". 
This is happend if it is more than 50 characters.

#### e.g.
"ここに文字列が入ります。ここに文字列が入ります。ここに文字列が入ります。ここに文字列が入ります。ここに文字列が入ります。”

#### expect
"ここに文字列が入ります。ここに文字列が入ります。ここに文字列が入ります。ここに文字列が入ります。ここに..."

#### real
"..."


The problem occurred because Japanese does not separate words with spaces.
So I changed it so that the last word is deleted only when there are three or more words separated by spaces.

