### PR TITLE
Added web.config for IIS compatibility

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+     <staticContent>
+      <mimeMap fileExtension=".css" mimeType="text/css; charset=UTF-8" />
+      <mimeMap fileExtension="woff" mimeType="application/font-woff" />
+      <mimeMap fileExtension="woff2" mimeType="application/font-woff" /> 
+      <mimeMap fileExtension=".js" mimeType="application/x-javascript" />
+      <mimeMap fileExtension=".handlebars" mimeType="text/x-handlebars-template" />
+      <mimeMap fileExtension=".tag" mimeType="text/x-javascript" />
+    </staticContent>
+  <rewrite>
+  <rules>
+    <rule name="Imported Rule 1" stopProcessing="true">
+      <match url="^.*/?\.git+" ignoreCase="false" />
+      <action type="CustomResponse" statusCode="403" statusReason="Forbidden" statusDescription="Forbidden" />
+    </rule>
+    <rule name="Imported Rule 2" stopProcessing="true">
+      <match url=".*" ignoreCase="false" />
+      <conditions>
+        <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" ignoreCase="false" negate="true" />
+      </conditions>
+      <action type="Rewrite" url="index.php" />
+    </rule>
+  </rules>
+</rewrite>
+</system.webServer>
+</configuration> 


### PR DESCRIPTION
Cockpit does not support IIS out of the box (missing .tag mime-types, etc). For IIS webserver compatibility we require this web.config file. Please note that this file is a first setup and can be improved.

Many thanks to @jpgollnitz for this file.
https://github.com/agentejo/cockpit/issues/726#issuecomment-453175951


